### PR TITLE
Upgrade to OpenSearch 3.x APIs and align with cluster manager terminology

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v2
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>fesen-httpclient</artifactId>
 	<packaging>jar</packaging>
 	<name>fesen-httpclient</name>
-	<version>2.19.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<description />
 	<url>https://github.com/codelibs/fesen-httpclient</url>
 	<inceptionYear>2012</inceptionYear>
@@ -36,10 +36,10 @@
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>2.19.1</opensearch.version>
+		<opensearch.version>3.0.0</opensearch.version>
 		<log4j.version>2.21.0</log4j.version>
-		<junit.jupiter.version>5.10.0</junit.jupiter.version>
-		<testcontainers.version>1.19.1</testcontainers.version>
+		<junit.jupiter.version>5.12.2</junit.jupiter.version>
+		<testcontainers.version>1.21.0</testcontainers.version>
 	</properties>
 	<build>
 		<plugins>
@@ -192,7 +192,7 @@
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.11.3</version>
+			<version>1.12.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/codelibs/fesen/client/HttpAbstractClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpAbstractClient.java
@@ -284,6 +284,7 @@ import org.opensearch.action.admin.indices.rollover.RolloverAction;
 import org.opensearch.action.admin.indices.rollover.RolloverRequest;
 import org.opensearch.action.admin.indices.rollover.RolloverRequestBuilder;
 import org.opensearch.action.admin.indices.rollover.RolloverResponse;
+import org.opensearch.action.admin.indices.scale.searchonly.ScaleIndexRequestBuilder;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
@@ -309,6 +310,12 @@ import org.opensearch.action.admin.indices.stats.IndicesStatsAction;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionRequest;
+import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionRequest;
+import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateRequest;
+import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateResponse;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder;
@@ -405,7 +412,7 @@ import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.action.search.SearchScrollRequestBuilder;
 import org.opensearch.action.support.PlainActionFuture;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.termvectors.MultiTermVectorsAction;
 import org.opensearch.action.termvectors.MultiTermVectorsRequest;
 import org.opensearch.action.termvectors.MultiTermVectorsRequestBuilder;
@@ -418,12 +425,6 @@ import org.opensearch.action.update.UpdateAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateRequestBuilder;
 import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.Client;
-import org.opensearch.client.ClusterAdminClient;
-import org.opensearch.client.FilterClient;
-import org.opensearch.client.IndicesAdminClient;
-import org.opensearch.client.OpenSearchClient;
 import org.opensearch.cluster.metadata.IndexMetadata.APIBlock;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.action.ActionFuture;
@@ -435,6 +436,12 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.tasks.TaskId;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.FilterClient;
+import org.opensearch.transport.client.IndicesAdminClient;
+import org.opensearch.transport.client.OpenSearchClient;
 
 /**
  * Base client used to create concrete client implementations
@@ -2062,6 +2069,88 @@ public abstract class HttpAbstractClient implements Client {
         @Override
         public SegmentReplicationStatsRequestBuilder prepareSegmentReplicationStats(final String... indices) {
             return new SegmentReplicationStatsRequestBuilder(this, SegmentReplicationStatsAction.INSTANCE).setIndices(indices);
+        }
+
+        @Override
+        public void createView(org.opensearch.action.admin.indices.view.CreateViewAction.Request request,
+                ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> createView(
+                org.opensearch.action.admin.indices.view.CreateViewAction.Request request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void getView(org.opensearch.action.admin.indices.view.GetViewAction.Request request,
+                ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> getView(
+                org.opensearch.action.admin.indices.view.GetViewAction.Request request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void deleteView(org.opensearch.action.admin.indices.view.DeleteViewAction.Request request,
+                ActionListener<AcknowledgedResponse> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<AcknowledgedResponse> deleteView(org.opensearch.action.admin.indices.view.DeleteViewAction.Request request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void updateView(org.opensearch.action.admin.indices.view.CreateViewAction.Request request,
+                ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> updateView(
+                org.opensearch.action.admin.indices.view.CreateViewAction.Request request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<PauseIngestionResponse> pauseIngestion(PauseIngestionRequest request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void pauseIngestion(PauseIngestionRequest request, ActionListener<PauseIngestionResponse> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<ResumeIngestionResponse> resumeIngestion(ResumeIngestionRequest request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void resumeIngestion(ResumeIngestionRequest request, ActionListener<ResumeIngestionResponse> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ActionFuture<GetIngestionStateResponse> getIngestionState(GetIngestionStateRequest request) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public void getIngestionState(GetIngestionStateRequest request, ActionListener<GetIngestionStateResponse> listener) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
+        @Override
+        public ScaleIndexRequestBuilder prepareScaleSearchOnly(String index, boolean searchOnly) {
+            throw new UnsupportedOperationException("Not implemented yet");
         }
     }
 

--- a/src/main/java/org/codelibs/fesen/client/HttpAdminClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpAdminClient.java
@@ -15,9 +15,9 @@
  */
 package org.codelibs.fesen.client;
 
-import org.opensearch.client.AdminClient;
-import org.opensearch.client.ClusterAdminClient;
-import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.IndicesAdminClient;
 
 public class HttpAdminClient implements AdminClient {
 

--- a/src/main/java/org/codelibs/fesen/client/HttpClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpClient.java
@@ -273,11 +273,11 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.search.SearchScrollRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.AdminClient;
+import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -371,6 +371,7 @@ import org.opensearch.search.aggregations.pipeline.ParsedStatsBucket;
 import org.opensearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregationBuilder;
 import org.opensearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
 
 public class HttpClient extends HttpAbstractClient {
 
@@ -1096,5 +1097,28 @@ public class HttpClient extends HttpAbstractClient {
             super(pool);
             setName("eshttp");
         }
+    }
+
+    @Override
+    public void searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request,
+            ActionListener<SearchResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<SearchResponse> searchView(org.opensearch.action.admin.indices.view.SearchViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void listViewNames(org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.ListViewNamesAction.Response> listViewNames(
+            org.opensearch.action.admin.indices.view.ListViewNamesAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/HttpIndicesAdminClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpIndicesAdminClient.java
@@ -76,6 +76,7 @@ import org.opensearch.action.admin.indices.replication.SegmentReplicationStatsRe
 import org.opensearch.action.admin.indices.rollover.RolloverRequest;
 import org.opensearch.action.admin.indices.rollover.RolloverRequestBuilder;
 import org.opensearch.action.admin.indices.rollover.RolloverResponse;
+import org.opensearch.action.admin.indices.scale.searchonly.ScaleIndexRequestBuilder;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequestBuilder;
@@ -93,6 +94,12 @@ import org.opensearch.action.admin.indices.shrink.ResizeResponse;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.opensearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionRequest;
+import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionRequest;
+import org.opensearch.action.admin.indices.streamingingestion.resume.ResumeIngestionResponse;
+import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateRequest;
+import org.opensearch.action.admin.indices.streamingingestion.state.GetIngestionStateResponse;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequestBuilder;
 import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
@@ -109,13 +116,13 @@ import org.opensearch.action.admin.indices.upgrade.post.UpgradeResponse;
 import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.opensearch.action.admin.indices.validate.query.ValidateQueryRequestBuilder;
 import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
-import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.IndexMetadata.APIBlock;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.IndicesAdminClient;
 
 public class HttpIndicesAdminClient implements IndicesAdminClient {
 
@@ -676,4 +683,85 @@ public class HttpIndicesAdminClient implements IndicesAdminClient {
         return indicesClient.prepareSegmentReplicationStats(indices);
     }
 
+    @Override
+    public void createView(org.opensearch.action.admin.indices.view.CreateViewAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> createView(
+            org.opensearch.action.admin.indices.view.CreateViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void getView(org.opensearch.action.admin.indices.view.GetViewAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> getView(
+            org.opensearch.action.admin.indices.view.GetViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void deleteView(org.opensearch.action.admin.indices.view.DeleteViewAction.Request request,
+            ActionListener<AcknowledgedResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<AcknowledgedResponse> deleteView(org.opensearch.action.admin.indices.view.DeleteViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void updateView(org.opensearch.action.admin.indices.view.CreateViewAction.Request request,
+            ActionListener<org.opensearch.action.admin.indices.view.GetViewAction.Response> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<org.opensearch.action.admin.indices.view.GetViewAction.Response> updateView(
+            org.opensearch.action.admin.indices.view.CreateViewAction.Request request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<PauseIngestionResponse> pauseIngestion(PauseIngestionRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void pauseIngestion(PauseIngestionRequest request, ActionListener<PauseIngestionResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<ResumeIngestionResponse> resumeIngestion(ResumeIngestionRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void resumeIngestion(ResumeIngestionRequest request, ActionListener<ResumeIngestionResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ActionFuture<GetIngestionStateResponse> getIngestionState(GetIngestionStateRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void getIngestionState(GetIngestionStateRequest request, ActionListener<GetIngestionStateResponse> listener) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ScaleIndexRequestBuilder prepareScaleSearchOnly(String index, boolean searchOnly) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterRerouteAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterRerouteAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.action.admin.cluster.reroute.ClusterRerouteAction;
 import org.opensearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.opensearch.action.admin.cluster.reroute.ClusterRerouteResponse;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
@@ -19,7 +19,7 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.action.admin.indices.delete.DeleteIndexAction;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexTemplateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexTemplateAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateAction;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeletePipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeletePipelineAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.ingest.DeletePipelineAction;
 import org.opensearch.action.ingest.DeletePipelineRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteRepositoryAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteSnapshotAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteSnapshotAction.java
@@ -23,7 +23,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotAction;
 import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteStoredScriptAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteStoredScriptAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.cluster.storedscripts.DeleteStoredScriptAction;
 import org.opensearch.action.admin.cluster.storedscripts.DeleteStoredScriptRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexAction.java
@@ -32,6 +32,7 @@ import org.opensearch.action.admin.indices.get.GetIndexAction;
 import org.opensearch.action.admin.indices.get.GetIndexRequest;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
 import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.Context;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
@@ -70,6 +71,7 @@ public class HttpGetIndexAction extends HttpAction {
         final Map<String, Settings> settings = new HashMap<>();
         final Map<String, Settings> defaultSettings = new HashMap<>();
         final Map<String, String> dataStreams = new HashMap<>();
+        final Map<String, Context> contexts = new HashMap<String, Context>();
         final List<String> indices = new ArrayList<>();
 
         if (parser.currentToken() == null) {
@@ -95,13 +97,14 @@ public class HttpGetIndexAction extends HttpAction {
                 if (indexEntry.dataStream != null) {
                     dataStreams.put(indexName, indexEntry.dataStream);
                 }
+                // TODO contexts
             } else if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
                 parser.skipChildren();
             } else {
                 parser.nextToken();
             }
         }
-        return new GetIndexResponse(indices.toArray(new String[0]), mappings, aliases, settings, defaultSettings, dataStreams);
+        return new GetIndexResponse(indices.toArray(new String[0]), mappings, aliases, settings, defaultSettings, dataStreams, contexts);
     }
 
     protected static IndexEntry parseIndexEntry(final XContentParser parser) throws IOException {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
@@ -23,7 +23,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutIndexTemplateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutIndexTemplateAction.java
@@ -23,7 +23,7 @@ import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
@@ -19,7 +19,7 @@ import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingAction;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutPipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutPipelineAction.java
@@ -23,7 +23,7 @@ import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ingest.PutPipelineAction;
 import org.opensearch.action.ingest.PutPipelineRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
@@ -20,7 +20,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryAction;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutStoredScriptAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutStoredScriptAction.java
@@ -23,7 +23,7 @@ import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.storedscripts.PutStoredScriptAction;
 import org.opensearch.action.admin.cluster.storedscripts.PutStoredScriptRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
@@ -22,7 +22,7 @@ import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsAction;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;

--- a/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequrestBuilder.java
+++ b/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequrestBuilder.java
@@ -19,12 +19,12 @@ import java.util.Map;
 
 import org.opensearch.action.admin.indices.create.CreateIndexAction;
 import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
-import org.opensearch.client.OpenSearchClient;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.transport.client.OpenSearchClient;
 
 public class HttpCreateIndexRequrestBuilder extends CreateIndexRequestBuilder {
     private final HttpCreateIndexRequest request;

--- a/src/test/java/org/codelibs/fesen/client/Elasticsearch7ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/Elasticsearch7ClientTest.java
@@ -86,7 +86,7 @@ import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
@@ -107,6 +107,7 @@ import org.opensearch.search.SearchHit;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+@Deprecated
 class Elasticsearch7ClientTest {
     static final Logger logger = Logger.getLogger(Elasticsearch7ClientTest.class.getName());
 
@@ -241,7 +242,7 @@ class Elasticsearch7ClientTest {
         client.admin().indices().prepareCreate(index).execute().actionGet();
 
         client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute(wrap(res -> {
-            assertEquals(0, res.getHits().getTotalHits().value);
+            assertEquals(0, res.getHits().getTotalHits().value());
             latch.countDown();
         }, e -> {
             e.printStackTrace();
@@ -255,7 +256,7 @@ class Elasticsearch7ClientTest {
 
         {
             final SearchResponse searchResponse = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-            assertEquals(0, searchResponse.getHits().getTotalHits().value);
+            assertEquals(0, searchResponse.getHits().getTotalHits().value());
         }
     }
 
@@ -655,7 +656,7 @@ class Elasticsearch7ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
             latch.countDown();
@@ -675,7 +676,7 @@ class Elasticsearch7ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
         }
@@ -707,7 +708,7 @@ class Elasticsearch7ClientTest {
         // Search the document
         final SearchResponse searchResponse =
                 client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).setSize(0).execute().actionGet();
-        assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        assertEquals(1, searchResponse.getHits().getTotalHits().value());
 
         // Get the document
         final GetResponse getResponse2 = client.prepareGet().setIndex(index).setId(id).execute().actionGet();
@@ -743,7 +744,7 @@ class Elasticsearch7ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse1 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value);
+        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value());
 
         // Get the documents with MultiGet API
         final MultiGetRequestBuilder mgetRequestBuilder = client.prepareMultiGet();
@@ -760,7 +761,7 @@ class Elasticsearch7ClientTest {
         client.admin().indices().prepareRefresh(index).execute().actionGet();
 
         final SearchResponse searchResponse2 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value);
+        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value());
 
         // Delete all the documents with Bulk API
         final BulkRequestBuilder bulkRequestBuilder2 = client.prepareBulk();
@@ -772,7 +773,7 @@ class Elasticsearch7ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse3 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(0, searchResponse3.getHits().getTotalHits().value);
+        assertEquals(0, searchResponse3.getHits().getTotalHits().value());
     }
 
     @Test

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
@@ -86,7 +86,7 @@ import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
@@ -107,6 +107,7 @@ import org.opensearch.search.SearchHit;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
+@Deprecated
 class OpenSearch1ClientTest {
     static final Logger logger = Logger.getLogger(OpenSearch1ClientTest.class.getName());
 
@@ -242,7 +243,7 @@ class OpenSearch1ClientTest {
         client.admin().indices().prepareCreate(index).execute().actionGet();
 
         client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute(wrap(res -> {
-            assertEquals(0, res.getHits().getTotalHits().value);
+            assertEquals(0, res.getHits().getTotalHits().value());
             latch.countDown();
         }, e -> {
             e.printStackTrace();
@@ -256,7 +257,7 @@ class OpenSearch1ClientTest {
 
         {
             final SearchResponse searchResponse = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-            assertEquals(0, searchResponse.getHits().getTotalHits().value);
+            assertEquals(0, searchResponse.getHits().getTotalHits().value());
         }
     }
 
@@ -656,7 +657,7 @@ class OpenSearch1ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
             latch.countDown();
@@ -676,7 +677,7 @@ class OpenSearch1ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
         }
@@ -708,7 +709,7 @@ class OpenSearch1ClientTest {
         // Search the document
         final SearchResponse searchResponse =
                 client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).setSize(0).execute().actionGet();
-        assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        assertEquals(1, searchResponse.getHits().getTotalHits().value());
 
         // Get the document
         final GetResponse getResponse2 = client.prepareGet().setIndex(index).setId(id).execute().actionGet();
@@ -744,7 +745,7 @@ class OpenSearch1ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse1 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value);
+        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value());
 
         // Get the documents with MultiGet API
         final MultiGetRequestBuilder mgetRequestBuilder = client.prepareMultiGet();
@@ -761,7 +762,7 @@ class OpenSearch1ClientTest {
         client.admin().indices().prepareRefresh(index).execute().actionGet();
 
         final SearchResponse searchResponse2 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value);
+        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value());
 
         // Delete all the documents with Bulk API
         final BulkRequestBuilder bulkRequestBuilder2 = client.prepareBulk();
@@ -773,7 +774,7 @@ class OpenSearch1ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse3 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(0, searchResponse3.getHits().getTotalHits().value);
+        assertEquals(0, searchResponse3.getHits().getTotalHits().value());
     }
 
     @Test

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch2ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch2ClientTest.java
@@ -87,7 +87,7 @@ import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.settings.Settings;
@@ -106,7 +106,6 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.search.SearchHit;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 import org.testcontainers.utility.DockerImageName;
 
 class OpenSearch2ClientTest {
@@ -245,7 +244,7 @@ class OpenSearch2ClientTest {
         client.admin().indices().prepareCreate(index).execute().actionGet();
 
         client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute(wrap(res -> {
-            assertEquals(0, res.getHits().getTotalHits().value);
+            assertEquals(0, res.getHits().getTotalHits().value());
             latch.countDown();
         }, e -> {
             e.printStackTrace();
@@ -259,7 +258,7 @@ class OpenSearch2ClientTest {
 
         {
             final SearchResponse searchResponse = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-            assertEquals(0, searchResponse.getHits().getTotalHits().value);
+            assertEquals(0, searchResponse.getHits().getTotalHits().value());
         }
     }
 
@@ -659,7 +658,7 @@ class OpenSearch2ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
             latch.countDown();
@@ -679,7 +678,7 @@ class OpenSearch2ClientTest {
             long nbHits = 0;
             for (final MultiSearchResponse.Item item : res.getResponses()) {
                 final SearchResponse searchResponse = item.getResponse();
-                nbHits += searchResponse.getHits().getTotalHits().value;
+                nbHits += searchResponse.getHits().getTotalHits().value();
             }
             assertEquals(0, nbHits);
         }
@@ -711,7 +710,7 @@ class OpenSearch2ClientTest {
         // Search the document
         final SearchResponse searchResponse =
                 client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).setSize(0).execute().actionGet();
-        assertEquals(1, searchResponse.getHits().getTotalHits().value);
+        assertEquals(1, searchResponse.getHits().getTotalHits().value());
 
         // Get the document
         final GetResponse getResponse2 = client.prepareGet().setIndex(index).setId(id).execute().actionGet();
@@ -747,7 +746,7 @@ class OpenSearch2ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse1 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value);
+        assertEquals(NUM, searchResponse1.getHits().getTotalHits().value());
 
         // Get the documents with MultiGet API
         final MultiGetRequestBuilder mgetRequestBuilder = client.prepareMultiGet();
@@ -764,7 +763,7 @@ class OpenSearch2ClientTest {
         client.admin().indices().prepareRefresh(index).execute().actionGet();
 
         final SearchResponse searchResponse2 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value);
+        assertEquals(NUM - 1, searchResponse2.getHits().getTotalHits().value());
 
         // Delete all the documents with Bulk API
         final BulkRequestBuilder bulkRequestBuilder2 = client.prepareBulk();
@@ -776,7 +775,7 @@ class OpenSearch2ClientTest {
 
         // Search the documents
         final SearchResponse searchResponse3 = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
-        assertEquals(0, searchResponse3.getHits().getTotalHits().value);
+        assertEquals(0, searchResponse3.getHits().getTotalHits().value());
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces several updates across the project, including upgrading dependencies, adding new features, and refactoring imports to align with updated APIs. The most significant changes involve upgrading to OpenSearch 3.0.0, updating dependencies, and adding placeholders for new API methods related to views and ingestion.

### Dependency and Version Upgrades:
* Updated the JDK version in `.github/workflows/maven.yml` from 17 to 21 to align with modern Java standards. (`[.github/workflows/maven.ymlL23-R26](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L23-R26)`)
* Upgraded the project version in `pom.xml` to `3.0.0-SNAPSHOT`, along with updates to dependencies such as OpenSearch (`3.0.0`), JUnit Jupiter (`5.12.2`), Testcontainers (`1.21.0`), and JUnit Platform Launcher (`1.12.2`). (`[[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8)`, `[[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R42)`, `[[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L195-R195)`)

### New Features (Placeholders for APIs):
* Added placeholders for new API methods in `HttpAbstractClient`, `HttpClient`, and `HttpIndicesAdminClient` to support view management (`createView`, `getView`, `updateView`, `deleteView`) and ingestion control (`pauseIngestion`, `resumeIngestion`, `getIngestionState`). These methods currently throw `UnsupportedOperationException`. (`[[1]](diffhunk://#diff-c176ad038255d1f0a0f2563b0d1b0c4e1085c58ae5a8f809c343ad7084474f3fR2073-R2154)`, `[[2]](diffhunk://#diff-41e385a94d02cc8a9e1a653fa1fe60a7404dfa8410f44047f4c2f34c278aa85fR1101-R1123)`, `[[3]](diffhunk://#diff-0f536e391ef241aa338b692e0c4fb5ae9b58d4f589a0dac87b3b62d2f36c1755R686-R766)`)

### Refactoring and API Alignment:
* Refactored imports across multiple files to replace `master` terminology with `clustermanager`, aligning with OpenSearch 3.0.0's updated API. (`[[1]](diffhunk://#diff-c176ad038255d1f0a0f2563b0d1b0c4e1085c58ae5a8f809c343ad7084474f3fL408-R415)`, `[[2]](diffhunk://#diff-41e385a94d02cc8a9e1a653fa1fe60a7404dfa8410f44047f4c2f34c278aa85fL276-R280)`, `[[3]](diffhunk://#diff-9284170a24dd71b5855eb70ef2b7b2e5d6031b5b0e0f205c0dcf1e0fe3941d7fL23-R23)`, `[[4]](diffhunk://#diff-b7e6ee4aabbc730b906eaec2fa087247b0a2889a6ddea4ebb2e44b400cfd7078L22-R22)`)
* Replaced deprecated `org.opensearch.client` imports with `org.opensearch.transport.client` in `HttpAbstractClient`, `HttpAdminClient`, and `HttpIndicesAdminClient` for better compatibility with OpenSearch 3.0.0. (`[[1]](diffhunk://#diff-c176ad038255d1f0a0f2563b0d1b0c4e1085c58ae5a8f809c343ad7084474f3fL421-L426)`, `[[2]](diffhunk://#diff-8f4771492c5c6a23b1788f86bfcf7a127dd987a59b9e87586ae051410e01efbfL18-R20)`, `[[3]](diffhunk://#diff-0f536e391ef241aa338b692e0c4fb5ae9b58d4f589a0dac87b3b62d2f36c1755L112-R125)`)

### Minor Additions:
* Added new imports for `ScaleIndexRequestBuilder` and ingestion-related classes in `HttpAbstractClient` and `HttpIndicesAdminClient` to support future functionality. (`[[1]](diffhunk://#diff-c176ad038255d1f0a0f2563b0d1b0c4e1085c58ae5a8f809c343ad7084474f3fR287)`, `[[2]](diffhunk://#diff-0f536e391ef241aa338b692e0c4fb5ae9b58d4f589a0dac87b3b62d2f36c1755R79)`, `[[3]](diffhunk://#diff-0f536e391ef241aa338b692e0c4fb5ae9b58d4f589a0dac87b3b62d2f36c1755R97-R102)`)