### PR TITLE
chore(deps): bump build plugins and curl4j, gate GPG signing on release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.14.0</version>
+				<version>3.15.0</version>
 				<configuration>
 					<release>17</release>
 					<encoding>UTF-8</encoding>
@@ -54,7 +54,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.11.2</version>
+				<version>3.12.0</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
@@ -64,7 +64,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.3</version>
+				<version>3.5.5</version>
 				<configuration>
 					<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.13</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>
@@ -113,7 +113,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.26.0</version>
+				<version>2.29.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -126,23 +126,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.10.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>
@@ -150,6 +136,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>
@@ -176,7 +188,7 @@
 		<dependency>
 			<groupId>org.codelibs</groupId>
 			<artifactId>curl4j</artifactId>
-			<version>1.3.0</version>
+			<version>1.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
Routine maintenance bump of build plugins and the `curl4j` dependency, plus a small build-config change so non-release builds no longer require a GPG key.

## Changes Made
- **Build plugin bumps**
  - `maven-compiler-plugin` 3.14.0 → 3.15.0
  - `maven-javadoc-plugin` 3.11.2 → 3.12.0
  - `maven-surefire-plugin` 3.5.3 → 3.5.5
  - `jacoco-maven-plugin` 0.8.13 → 0.8.14
  - `formatter-maven-plugin` 2.26.0 → 2.29.0
  - `central-publishing-maven-plugin` 0.7.0 → 0.10.0
- **GPG signing moved to a `release` profile**
  - `maven-gpg-plugin` 3.2.7 → 3.2.8
  - Plugin is now declared under a `release` profile with `<bestPractices>true</bestPractices>`, so artifact signing only runs when `-Prelease` is active. Default `mvn install` no longer fails for contributors without a GPG key configured.
- **Runtime dependency bump**
  - `org.codelibs:curl4j` 1.3.0 → 1.3.2

## Testing
- `mvn install` locally with the new plugin versions (without `-Prelease`) to confirm the build succeeds without GPG.
- The `maven-release-plugin` flow should be invoked with `-Prelease` (or the existing release script) to ensure artifacts are still signed at release time.

## Breaking Changes
- Release tooling must now pass `-Prelease` to trigger GPG signing. Anyone running release commands manually should update their command line accordingly. No source/API changes.

## Additional Notes
- Reviewer sanity check: confirm the release profile activation matches how the `maven-release-plugin` is invoked (CI script, release docs) so that signed artifacts continue to be produced for Sonatype Central.