### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v2 to v4
- Bump `actions/setup-java` from v2 to v4

These updates bring the workflow onto currently maintained Node.js 20-based action runtimes, eliminating deprecation warnings from GitHub.

## Test plan
- [ ] CI (Java CI with Maven) passes on this PR