### PR TITLE
Pull OpenSearch test images from ECR Public registry

### DIFF
--- a/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
@@ -113,7 +113,7 @@ class OpenSearch1ClientTest {
 
     static final String version = "1.3.20";
 
-    static final String imageTag = "opensearchproject/opensearch:" + version;
+    static final String imageTag = "public.ecr.aws/opensearchproject/opensearch:" + version;
 
     static String clusterName = "docker-cluster";
 

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch2ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch2ClientTest.java
@@ -113,7 +113,7 @@ class OpenSearch2ClientTest {
 
     static final String version = "2.19.4";
 
-    static final String imageTag = "opensearchproject/opensearch:" + version;
+    static final String imageTag = "public.ecr.aws/opensearchproject/opensearch:" + version;
 
     static String clusterName = "docker-cluster";
 

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
@@ -113,7 +113,7 @@ class OpenSearch3ClientTest {
 
     static final String version = "3.5.0";
 
-    static final String imageTag = "opensearchproject/opensearch:" + version;
+    static final String imageTag = "public.ecr.aws/opensearchproject/opensearch:" + version;
 
     static String clusterName = "docker-cluster";
 


### PR DESCRIPTION
## Summary

Use the ECR Public registry for the Testcontainers image in the OpenSearch client tests.

- `opensearchproject/opensearch` → `public.ecr.aws/opensearchproject/opensearch`

The version tag is unchanged; only the registry prefix is added. `DockerImageName.parse` handles the fully-qualified image name, so no compatibility annotation is needed.

## Why

Pulling from `public.ecr.aws` avoids Docker Hub anonymous pull rate limits during CI.

## Scope

- `OpenSearch1ClientTest.java`
- `OpenSearch2ClientTest.java`
- `OpenSearch3ClientTest.java`