### PR TITLE
chore(deps): bump OpenSearch to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.codelibs.fesen.client</groupId>
     <artifactId>fesen-httpclient</artifactId>
-    <version>3.2.0</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ Add the following dependency to your `pom.xml`:
 Add to your `build.gradle`:
 
 ```gradle
-implementation 'org.codelibs.fesen.client:fesen-httpclient:3.2.0'
+implementation 'org.codelibs.fesen.client:fesen-httpclient:3.7.0'
 ```
 
 ## 🏃 Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>fesen-httpclient</artifactId>
 	<packaging>jar</packaging>
 	<name>fesen-httpclient</name>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<description>HTTP client for OpenSearch</description>
 	<url>https://github.com/codelibs/fesen-httpclient</url>
 	<inceptionYear>2012</inceptionYear>
@@ -38,7 +38,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<opensearch.version>3.7.0</opensearch.version>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<junit.jupiter.version>5.12.2</junit.jupiter.version>
 		<testcontainers.version>1.21.4</testcontainers.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.version>3.7.0</opensearch.version>
 		<log4j.version>2.25.3</log4j.version>
 		<junit.jupiter.version>5.12.2</junit.jupiter.version>
 		<testcontainers.version>1.21.4</testcontainers.version>

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
@@ -350,13 +350,18 @@ public class HttpNodesStatsAction extends HttpAction {
                 clusterManagerThrottlingStats, //
                 weightedRoutingStats, //
                 fileCacheStats, //
+                null, //
+                null, //
                 taskCancellationStats, //
                 searchPipelineStats, //
                 segmentReplicationRejectionStats, //
                 repositoriesStats, //
                 admissionControlStats, //
                 nodeCacheStats, //
-                remoteStoreNodeStats);
+                remoteStoreNodeStats, //
+                null, //
+                null, //
+                -1L);
     }
 
     public static TransportAddress parseTransportAddress(final String addr) {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
@@ -86,6 +86,9 @@ import org.opensearch.index.store.StoreStats;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats.FileCacheStatsType;
 import org.opensearch.index.store.remote.filecache.FileCacheStats;
+import org.opensearch.plugin.stats.AnalyticsBackendNativeMemoryStats;
+import org.opensearch.plugin.stats.NativeAllocatorPoolStats;
+import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.index.translog.TranslogStats;
 import org.opensearch.index.warmer.WarmerStats;
 import org.opensearch.indices.NodeIndicesStats;
@@ -227,6 +230,8 @@ public class HttpNodesStatsAction extends HttpAction {
         ClusterManagerThrottlingStats clusterManagerThrottlingStats = null;
         WeightedRoutingStats weightedRoutingStats = null;
         AggregateFileCacheStats fileCacheStats = null;
+        AggregateFileCacheStats fileCacheOnlyStats = null;
+        BlockCacheStats blockCacheOnlyStats = null;
         TaskCancellationStats taskCancellationStats = null;
         SearchPipelineStats searchPipelineStats = null;
         SegmentReplicationRejectionStats segmentReplicationRejectionStats = null;
@@ -234,6 +239,9 @@ public class HttpNodesStatsAction extends HttpAction {
         AdmissionControlStats admissionControlStats = null;
         NodeCacheStats nodeCacheStats = null;
         RemoteStoreNodeStats remoteStoreNodeStats = null;
+        NativeAllocatorPoolStats nativeAllocatorStats = null;
+        AnalyticsBackendNativeMemoryStats nativeMemoryStats = null;
+        long totalEstimatedNativeBytes = -1L;
         final Map<String, String> attributes = new HashMap<>();
         XContentParser.Token token;
         TransportAddress transportAddress = new TransportAddress(TransportAddress.META_ADDRESS, 0);
@@ -283,8 +291,34 @@ public class HttpNodesStatsAction extends HttpAction {
                     clusterManagerThrottlingStats = parseClusterManagerThrottlingStats(parser);
                 } else if ("weighted_routing".equals(fieldName)) {
                     weightedRoutingStats = parseWeightedRoutingStats(parser);
-                } else if ("file_cache".equals(fieldName)) {
+                } else if ("aggregate_file_cache".equals(fieldName)) {
                     fileCacheStats = parseAggregateFileCacheStats(parser);
+                } else if ("file_cache".equals(fieldName)) {
+                    fileCacheOnlyStats = parseAggregateFileCacheStats(parser);
+                } else if ("block_cache".equals(fieldName)) {
+                    blockCacheOnlyStats = parseBlockCacheStats(parser);
+                } else if ("native_memory".equals(fieldName)) {
+                    String nmFieldName = null;
+                    XContentParser.Token nmToken;
+                    while ((nmToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (nmToken == XContentParser.Token.FIELD_NAME) {
+                            nmFieldName = parser.currentName();
+                        } else if (nmToken == XContentParser.Token.VALUE_NUMBER) {
+                            if ("total_estimated_bytes".equals(nmFieldName)) {
+                                totalEstimatedNativeBytes = parser.longValue();
+                            }
+                        } else if (nmToken == XContentParser.Token.START_OBJECT) {
+                            parser.nextToken();
+                            if ("analytics_backend".equals(nmFieldName)) {
+                                nativeMemoryStats = parseAnalyticsBackendNativeMemoryStats(parser);
+                            } else if ("native_allocator".equals(nmFieldName)) {
+                                nativeAllocatorStats = parseNativeAllocatorPoolStats(parser);
+                            } else {
+                                consumeObject(parser);
+                            }
+                        }
+                        parser.nextToken();
+                    }
                 } else if ("task_cancellation".equals(fieldName)) {
                     taskCancellationStats = parseTaskCancellationStats(parser);
                 } else if ("search_pipeline".equals(fieldName)) {
@@ -350,8 +384,8 @@ public class HttpNodesStatsAction extends HttpAction {
                 clusterManagerThrottlingStats, //
                 weightedRoutingStats, //
                 fileCacheStats, //
-                null, //
-                null, //
+                fileCacheOnlyStats, //
+                blockCacheOnlyStats, //
                 taskCancellationStats, //
                 searchPipelineStats, //
                 segmentReplicationRejectionStats, //
@@ -359,9 +393,9 @@ public class HttpNodesStatsAction extends HttpAction {
                 admissionControlStats, //
                 nodeCacheStats, //
                 remoteStoreNodeStats, //
-                null, //
-                null, //
-                -1L);
+                nativeAllocatorStats, //
+                nativeMemoryStats, //
+                totalEstimatedNativeBytes);
     }
 
     public static TransportAddress parseTransportAddress(final String addr) {
@@ -550,6 +584,150 @@ public class HttpNodesStatsAction extends HttpAction {
             pinnedFileStats = new FileCacheStats(0, 0, 0, 0, 0, 0, 0, 0, FileCacheStatsType.PINNED_FILE_STATS);
         }
         return new AggregateFileCacheStats(timestamp, overAllStats, fullFileStats, blockFileStats, pinnedFileStats);
+    }
+
+    protected BlockCacheStats parseBlockCacheStats(final XContentParser parser) throws IOException {
+        // Parse from over_all_stats sub-object; consume the other 3 sub-objects.
+        // JSON fields available in over_all_stats:
+        //   hit_count -> hits, miss_count -> misses, evictions_in_bytes -> evictionBytes,
+        //   removed_in_bytes -> removedBytes, active_in_bytes -> activeInBytes,
+        //   used_in_bytes -> memoryBytesUsed (server emits used_in_bytes = memoryBytesUsed + diskBytesUsed;
+        //   the split is not recoverable from JSON, so assign the combined value to memoryBytesUsed and 0
+        //   to diskBytesUsed -- re-serializing then reproduces the same used_in_bytes).
+        // hitBytes, missBytes, evictions, removed, diskBytesUsed, totalBytes -> 0 (not emitted by server).
+        long hits = 0;
+        long misses = 0;
+        long evictionBytes = 0;
+        long removedBytes = 0;
+        long activeInBytes = 0;
+        long memoryBytesUsed = 0;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("over_all_stats".equals(fieldName)) {
+                    String subField = null;
+                    XContentParser.Token subToken;
+                    while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (subToken == XContentParser.Token.FIELD_NAME) {
+                            subField = parser.currentName();
+                        } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                            if ("hit_count".equals(subField)) {
+                                hits = parser.longValue();
+                            } else if ("miss_count".equals(subField)) {
+                                misses = parser.longValue();
+                            } else if ("evictions_in_bytes".equals(subField)) {
+                                evictionBytes = parser.longValue();
+                            } else if ("removed_in_bytes".equals(subField)) {
+                                removedBytes = parser.longValue();
+                            } else if ("active_in_bytes".equals(subField)) {
+                                activeInBytes = parser.longValue();
+                            } else if ("used_in_bytes".equals(subField)) {
+                                memoryBytesUsed = parser.longValue();
+                            }
+                        }
+                        parser.nextToken();
+                    }
+                } else {
+                    consumeObject(parser);
+                }
+            }
+            parser.nextToken();
+        }
+        return new BlockCacheStats(hits, misses, 0L, 0L, 0L, evictionBytes, 0L, removedBytes, memoryBytesUsed, 0L, 0L, activeInBytes);
+    }
+
+    protected AnalyticsBackendNativeMemoryStats parseAnalyticsBackendNativeMemoryStats(final XContentParser parser) throws IOException {
+        long allocatedBytes = 0;
+        long residentBytes = 0;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("allocated_bytes".equals(fieldName)) {
+                    allocatedBytes = parser.longValue();
+                } else if ("resident_bytes".equals(fieldName)) {
+                    residentBytes = parser.longValue();
+                }
+            }
+            parser.nextToken();
+        }
+        return new AnalyticsBackendNativeMemoryStats(allocatedBytes, residentBytes);
+    }
+
+    protected NativeAllocatorPoolStats parseNativeAllocatorPoolStats(final XContentParser parser) throws IOException {
+        long rootAllocatedBytes = 0;
+        long rootPeakBytes = 0;
+        long rootLimitBytes = 0;
+        final List<NativeAllocatorPoolStats.PoolStats> pools = new ArrayList<>();
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("root".equals(fieldName)) {
+                    String subField = null;
+                    XContentParser.Token subToken;
+                    while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (subToken == XContentParser.Token.FIELD_NAME) {
+                            subField = parser.currentName();
+                        } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                            if ("allocated_bytes".equals(subField)) {
+                                rootAllocatedBytes = parser.longValue();
+                            } else if ("peak_bytes".equals(subField)) {
+                                rootPeakBytes = parser.longValue();
+                            } else if ("limit_bytes".equals(subField)) {
+                                rootLimitBytes = parser.longValue();
+                            }
+                        }
+                        parser.nextToken();
+                    }
+                } else if ("pools".equals(fieldName)) {
+                    String poolName = null;
+                    XContentParser.Token poolToken;
+                    while ((poolToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (poolToken == XContentParser.Token.FIELD_NAME) {
+                            poolName = parser.currentName();
+                        } else if (poolToken == XContentParser.Token.START_OBJECT) {
+                            parser.nextToken();
+                            long allocatedBytes = 0;
+                            long peakBytes = 0;
+                            long limitBytes = 0;
+                            final String name = poolName;
+                            String subField = null;
+                            XContentParser.Token subToken;
+                            while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                                if (subToken == XContentParser.Token.FIELD_NAME) {
+                                    subField = parser.currentName();
+                                } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                                    if ("allocated_bytes".equals(subField)) {
+                                        allocatedBytes = parser.longValue();
+                                    } else if ("peak_bytes".equals(subField)) {
+                                        peakBytes = parser.longValue();
+                                    } else if ("limit_bytes".equals(subField)) {
+                                        limitBytes = parser.longValue();
+                                    }
+                                }
+                                parser.nextToken();
+                            }
+                            pools.add(new NativeAllocatorPoolStats.PoolStats(name, allocatedBytes, peakBytes, limitBytes));
+                        }
+                        parser.nextToken();
+                    }
+                } else {
+                    consumeObject(parser);
+                }
+            }
+            parser.nextToken();
+        }
+        return new NativeAllocatorPoolStats(rootAllocatedBytes, rootPeakBytes, rootLimitBytes, pools);
     }
 
     protected TaskCancellationStats parseTaskCancellationStats(final XContentParser parser) throws IOException {
@@ -2378,6 +2556,9 @@ public class HttpNodesStatsAction extends HttpAction {
         final CurlRequest curlRequest = client.getCurlRequest(GET, buf.toString());
         if (request.timeout() != null) {
             curlRequest.param("timeout", request.timeout().toString());
+        }
+        if (request.isFileCacheDetailed()) {
+            curlRequest.param("detailed", "true");
         }
         return curlRequest;
     }

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
@@ -111,7 +111,7 @@ import org.testcontainers.utility.DockerImageName;
 class OpenSearch3ClientTest {
     static final Logger logger = Logger.getLogger(OpenSearch3ClientTest.class.getName());
 
-    static final String version = "3.5.0";
+    static final String version = "3.7.0";
 
     static final String imageTag = "public.ecr.aws/opensearchproject/opensearch:" + version;
 

--- a/src/test/java/org/codelibs/fesen/client/action/HttpNodesStatsActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpNodesStatsActionTest.java
@@ -17,6 +17,7 @@ package org.codelibs.fesen.client.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -31,15 +32,23 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsAction;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.plugin.stats.AnalyticsBackendNativeMemoryStats;
+import org.opensearch.plugin.stats.NativeAllocatorPoolStats;
+import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
 import org.opensearch.search.pipeline.SearchPipelineStats;
 import org.opensearch.tasks.TaskCancellationStats;
@@ -994,6 +1003,426 @@ class HttpNodesStatsActionTest {
         }
     }
 
+    // ==================== New helper methods for new parser methods ====================
+
+    private BlockCacheStats callParseBlockCacheStats(final XContentParser parser) throws Exception {
+        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseBlockCacheStats", XContentParser.class);
+        m.setAccessible(true);
+        return (BlockCacheStats) m.invoke(action, parser);
+    }
+
+    private AnalyticsBackendNativeMemoryStats callParseAnalyticsBackendNativeMemoryStats(final XContentParser parser) throws Exception {
+        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseAnalyticsBackendNativeMemoryStats", XContentParser.class);
+        m.setAccessible(true);
+        return (AnalyticsBackendNativeMemoryStats) m.invoke(action, parser);
+    }
+
+    private NativeAllocatorPoolStats callParseNativeAllocatorPoolStats(final XContentParser parser) throws Exception {
+        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseNativeAllocatorPoolStats", XContentParser.class);
+        m.setAccessible(true);
+        return (NativeAllocatorPoolStats) m.invoke(action, parser);
+    }
+
+    // ==================== parseNativeAllocatorPoolStats tests ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNativeAllocatorPoolStats_fullParse() throws Exception {
+        final String json = "{" + "\"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30}," + "\"pools\":{"
+                + "  \"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3},"
+                + "  \"pool-b\":{\"allocated_bytes\":4,\"peak_bytes\":5,\"limit_bytes\":6}" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken(); // advance past START_OBJECT into first field
+            final NativeAllocatorPoolStats stats = callParseNativeAllocatorPoolStats(parser);
+            assertNotNull(stats);
+            assertEquals(10L, stats.getRootAllocatedBytes());
+            assertEquals(20L, stats.getRootPeakBytes());
+            assertEquals(30L, stats.getRootLimitBytes());
+            assertEquals(2, stats.getPools().size());
+            final NativeAllocatorPoolStats.PoolStats poolA = stats.getPools().get(0);
+            assertEquals("pool-a", poolA.getName());
+            assertEquals(1L, poolA.getAllocatedBytes());
+            assertEquals(2L, poolA.getPeakBytes());
+            assertEquals(3L, poolA.getLimitBytes());
+            final NativeAllocatorPoolStats.PoolStats poolB = stats.getPools().get(1);
+            assertEquals("pool-b", poolB.getName());
+            assertEquals(4L, poolB.getAllocatedBytes());
+            assertEquals(5L, poolB.getPeakBytes());
+            assertEquals(6L, poolB.getLimitBytes());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNativeAllocatorPoolStats_noPools() throws Exception {
+        final String json = "{\"root\":{\"allocated_bytes\":100,\"peak_bytes\":200,\"limit_bytes\":300}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NativeAllocatorPoolStats stats = callParseNativeAllocatorPoolStats(parser);
+            assertNotNull(stats);
+            assertEquals(100L, stats.getRootAllocatedBytes());
+            assertEquals(200L, stats.getRootPeakBytes());
+            assertEquals(300L, stats.getRootLimitBytes());
+            assertNotNull(stats.getPools());
+            assertEquals(0, stats.getPools().size());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    // ==================== parseAnalyticsBackendNativeMemoryStats tests ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseAnalyticsBackendNativeMemoryStats_full() throws Exception {
+        final String json = "{\"allocated_bytes\":1111,\"resident_bytes\":2222}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final AnalyticsBackendNativeMemoryStats stats = callParseAnalyticsBackendNativeMemoryStats(parser);
+            assertNotNull(stats);
+            assertEquals(1111L, stats.getAllocatedBytes());
+            assertEquals(2222L, stats.getResidentBytes());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseAnalyticsBackendNativeMemoryStats_empty() throws Exception {
+        final String json = "{}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final AnalyticsBackendNativeMemoryStats stats = callParseAnalyticsBackendNativeMemoryStats(parser);
+            assertNotNull(stats);
+            assertEquals(0L, stats.getAllocatedBytes());
+            assertEquals(0L, stats.getResidentBytes());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    // ==================== parseBlockCacheStats tests ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseBlockCacheStats_full() throws Exception {
+        final String json = "{" + "\"over_all_stats\":{\"active_in_bytes\":800,\"used_in_bytes\":900,\"pinned_in_bytes\":0,"
+                + "  \"evictions_in_bytes\":50,\"removed_in_bytes\":30,\"active_percent\":0,\"hit_count\":500,\"miss_count\":100},"
+                + "\"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "  \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "\"block_file_stats\":{\"active_in_bytes\":800,\"used_in_bytes\":900,\"pinned_in_bytes\":0,"
+                + "  \"evictions_in_bytes\":50,\"removed_in_bytes\":30,\"active_percent\":0,\"hit_count\":500,\"miss_count\":100},"
+                + "\"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "  \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final BlockCacheStats stats = callParseBlockCacheStats(parser);
+            assertNotNull(stats);
+            assertEquals(500L, stats.hits());
+            assertEquals(100L, stats.misses());
+            assertEquals(50L, stats.evictionBytes());
+            assertEquals(30L, stats.removedBytes());
+            assertEquals(800L, stats.activeInBytes());
+            assertEquals(900L, stats.memoryBytesUsed());
+            assertEquals(0L, stats.hitBytes());
+            assertEquals(0L, stats.missBytes());
+            assertEquals(0L, stats.evictions());
+            assertEquals(0L, stats.removed());
+            assertEquals(0L, stats.diskBytesUsed());
+            assertEquals(0L, stats.totalBytes());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseBlockCacheStats_empty() throws Exception {
+        final String json = "{}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final BlockCacheStats stats = callParseBlockCacheStats(parser);
+            assertNotNull(stats);
+            assertEquals(0L, stats.hits());
+            assertEquals(0L, stats.misses());
+            assertEquals(0L, stats.hitBytes());
+            assertEquals(0L, stats.missBytes());
+            assertEquals(0L, stats.evictions());
+            assertEquals(0L, stats.evictionBytes());
+            assertEquals(0L, stats.removed());
+            assertEquals(0L, stats.removedBytes());
+            assertEquals(0L, stats.memoryBytesUsed());
+            assertEquals(0L, stats.diskBytesUsed());
+            assertEquals(0L, stats.totalBytes());
+            assertEquals(0L, stats.activeInBytes());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    // ==================== parseNodeStats: native_memory tests ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemoryFull() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\"," + "\"timestamp\":1234567890," + "\"native_memory\":{"
+                + "  \"total_estimated_bytes\":123456," + "  \"analytics_backend\":{\"allocated_bytes\":1111,\"resident_bytes\":2222},"
+                + "  \"native_allocator\":{" + "    \"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30},"
+                + "    \"pools\":{" + "      \"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3},"
+                + "      \"pool-b\":{\"allocated_bytes\":4,\"peak_bytes\":5,\"limit_bytes\":6}" + "    }" + "  }" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(123456L, nodeStats.getTotalEstimatedNativeBytes());
+            final AnalyticsBackendNativeMemoryStats nativeMemory = nodeStats.getAnalyticsBackendNativeMemoryStats();
+            assertNotNull(nativeMemory);
+            assertEquals(1111L, nativeMemory.getAllocatedBytes());
+            assertEquals(2222L, nativeMemory.getResidentBytes());
+            final NativeAllocatorPoolStats nativeAllocator = nodeStats.getNativeAllocatorStats();
+            assertNotNull(nativeAllocator);
+            assertEquals(10L, nativeAllocator.getRootAllocatedBytes());
+            assertEquals(20L, nativeAllocator.getRootPeakBytes());
+            assertEquals(30L, nativeAllocator.getRootLimitBytes());
+            assertEquals(2, nativeAllocator.getPools().size());
+            final NativeAllocatorPoolStats.PoolStats pool0 = nativeAllocator.getPools().get(0);
+            assertEquals("pool-a", pool0.getName());
+            assertEquals(1L, pool0.getAllocatedBytes());
+            assertEquals(2L, pool0.getPeakBytes());
+            assertEquals(3L, pool0.getLimitBytes());
+            final NativeAllocatorPoolStats.PoolStats pool1 = nativeAllocator.getPools().get(1);
+            assertEquals("pool-b", pool1.getName());
+            assertEquals(4L, pool1.getAllocatedBytes());
+            assertEquals(5L, pool1.getPeakBytes());
+            assertEquals(6L, pool1.getLimitBytes());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemoryMinimal() throws Exception {
+        final String json =
+                "{" + "\"name\":\"test-node\"," + "\"timestamp\":9999," + "\"native_memory\":{\"total_estimated_bytes\":99999}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(99999L, nodeStats.getTotalEstimatedNativeBytes());
+            assertNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
+            assertNull(nodeStats.getNativeAllocatorStats());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemoryAbsent() throws Exception {
+        final String json = "{\"name\":\"test-node\",\"timestamp\":111}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(-1L, nodeStats.getTotalEstimatedNativeBytes());
+            assertNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
+            assertNull(nodeStats.getNativeAllocatorStats());
+        }
+    }
+
+    // ==================== parseNodeStats: file cache dispatch tests ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_aggregateFileCache_populatesFileCacheStats() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\"," + "\"timestamp\":111," + "\"aggregate_file_cache\":{"
+                + "  \"timestamp\":123456789," + "  \"active_in_bytes\":100,\"total_in_bytes\":200,\"used_in_bytes\":150,"
+                + "  \"pinned_in_bytes\":10,\"evictions_in_bytes\":5,\"removed_in_bytes\":3,"
+                + "  \"active_percent\":50,\"used_percent\":75,\"hit_count\":42,\"miss_count\":7,"
+                + "  \"over_all_stats\":{\"active_in_bytes\":100,\"used_in_bytes\":150,\"pinned_in_bytes\":10,"
+                + "    \"evictions_in_bytes\":5,\"removed_in_bytes\":3,\"active_percent\":50,\"hit_count\":42,\"miss_count\":7},"
+                + "  \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "  \"block_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "  \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertNotNull(nodeStats.getFileCacheStats());
+            assertEquals(123456789L, nodeStats.getFileCacheStats().getTimestamp());
+            assertEquals(42L, nodeStats.getFileCacheStats().getCacheHits());
+            assertEquals(7L, nodeStats.getFileCacheStats().getCacheMisses());
+            assertNull(nodeStats.getFileCacheOnlyStats());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_fileCacheDetailed_populatesFileCacheOnlyStats() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\"," + "\"timestamp\":222," + "\"file_cache\":{"
+                + "  \"over_all_stats\":{\"active_in_bytes\":100,\"used_in_bytes\":150,\"pinned_in_bytes\":10,"
+                + "    \"evictions_in_bytes\":5,\"removed_in_bytes\":3,\"active_percent\":50,\"hit_count\":42,\"miss_count\":7},"
+                + "  \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "  \"block_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "  \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertNotNull(nodeStats.getFileCacheOnlyStats());
+            assertEquals(42L, nodeStats.getFileCacheOnlyStats().getCacheHits());
+            assertEquals(7L, nodeStats.getFileCacheOnlyStats().getCacheMisses());
+            assertNull(nodeStats.getFileCacheStats());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_blockCache_populatesBlockCacheOnlyStats() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\"," + "\"timestamp\":333," + "\"block_cache\":{"
+                + "  \"over_all_stats\":{\"active_in_bytes\":800,\"used_in_bytes\":900,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":50,\"removed_in_bytes\":30,\"active_percent\":0,\"hit_count\":500,\"miss_count\":100},"
+                + "  \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "  \"block_file_stats\":{\"active_in_bytes\":800,\"used_in_bytes\":900,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":50,\"removed_in_bytes\":30,\"active_percent\":0,\"hit_count\":500,\"miss_count\":100},"
+                + "  \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "    \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            final BlockCacheStats blockCache = nodeStats.getBlockCacheOnlyStats();
+            assertNotNull(blockCache);
+            assertEquals(500L, blockCache.hits());
+            assertEquals(100L, blockCache.misses());
+            assertEquals(50L, blockCache.evictionBytes());
+            assertEquals(30L, blockCache.removedBytes());
+            assertEquals(800L, blockCache.activeInBytes());
+            assertEquals(900L, blockCache.memoryBytesUsed());
+            assertEquals(0L, blockCache.hitBytes());
+            assertEquals(0L, blockCache.missBytes());
+            assertEquals(0L, blockCache.evictions());
+            assertEquals(0L, blockCache.removed());
+            assertEquals(0L, blockCache.diskBytesUsed());
+            assertEquals(0L, blockCache.totalBytes());
+        }
+    }
+
+    // ==================== Integration-style test: all new sections together ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_allNewSectionsTogether_withJvmAndOs() throws Exception {
+        final String json = "{" + "\"_nodes\":{\"total\":1,\"successful\":1,\"failed\":0}," + "\"cluster_name\":\"test-cluster\","
+                + "\"nodes\":{\"node1\":{" + "  \"name\":\"test-node\",\"timestamp\":9999," + "  \"transport_address\":\"127.0.0.1:9300\","
+                + "  \"jvm\":{" + "    \"timestamp\":9999,\"uptime_in_millis\":1000," + "    \"mem\":{"
+                + "      \"heap_used_in_bytes\":1000,\"heap_used_percent\":10,"
+                + "      \"heap_committed_in_bytes\":2000,\"heap_max_in_bytes\":2000,"
+                + "      \"non_heap_used_in_bytes\":100,\"non_heap_committed_in_bytes\":150" + "    },"
+                + "    \"threads\":{\"count\":10,\"peak_count\":15},"
+                + "    \"gc\":{\"collectors\":{\"young\":{\"collection_count\":5,\"collection_time_in_millis\":100},"
+                + "      \"old\":{\"collection_count\":1,\"collection_time_in_millis\":500}}},"
+                + "    \"classes\":{\"current_loaded_count\":100,\"total_loaded_count\":100,\"total_unloaded_count\":0},"
+                + "    \"buffer_pools\":{}" + "  }," + "  \"transport\":{\"server_open\":5,\"total_outbound_connections\":3,"
+                + "    \"rx_count\":100,\"rx_size_in_bytes\":5000,\"tx_count\":100,\"tx_size_in_bytes\":5000},"
+                + "  \"aggregate_file_cache\":{" + "    \"timestamp\":11111,"
+                + "    \"over_all_stats\":{\"active_in_bytes\":10,\"used_in_bytes\":20,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":1,\"removed_in_bytes\":0,\"active_percent\":50,\"hit_count\":5,\"miss_count\":2},"
+                + "    \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"block_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "  },"
+                + "  \"file_cache\":{" + "    \"over_all_stats\":{\"active_in_bytes\":10,\"used_in_bytes\":20,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":1,\"removed_in_bytes\":0,\"active_percent\":50,\"hit_count\":5,\"miss_count\":2},"
+                + "    \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"block_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "  },"
+                + "  \"block_cache\":{" + "    \"over_all_stats\":{\"active_in_bytes\":800,\"used_in_bytes\":900,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":50,\"removed_in_bytes\":30,\"active_percent\":0,\"hit_count\":500,\"miss_count\":100},"
+                + "    \"full_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"block_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0},"
+                + "    \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
+                + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "  },"
+                + "  \"native_memory\":{" + "    \"total_estimated_bytes\":123456,"
+                + "    \"analytics_backend\":{\"allocated_bytes\":1111,\"resident_bytes\":2222}," + "    \"native_allocator\":{"
+                + "      \"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30},"
+                + "      \"pools\":{\"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3}}" + "    }" + "  }" + "}}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            final NodesStatsResponse response = callFromXContent(parser);
+            assertNotNull(response);
+            assertEquals(1, response.getNodes().size());
+            final NodeStats node = response.getNodes().get(0);
+            assertEquals("test-node", node.getNode().getName());
+            assertNotNull(node.getFileCacheStats());
+            assertNotNull(node.getFileCacheOnlyStats());
+            assertNotNull(node.getBlockCacheOnlyStats());
+            assertEquals(123456L, node.getTotalEstimatedNativeBytes());
+            assertNotNull(node.getAnalyticsBackendNativeMemoryStats());
+            assertNotNull(node.getNativeAllocatorStats());
+            assertNotNull(node.getJvm());
+            assertNotNull(node.getTransport());
+        }
+    }
+
+    // ==================== Robustness: unknown nested fields in native_memory ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemory_unknownNestedObject_consumedGracefully() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"native_memory\":{" + "  \"total_estimated_bytes\":500,"
+                + "  \"future_field\":{\"nested\":{\"deep\":true},\"count\":42},"
+                + "  \"analytics_backend\":{\"allocated_bytes\":10,\"resident_bytes\":20}," + "  \"native_allocator\":{"
+                + "    \"root\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3}," + "    \"pools\":{}" + "  }" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(500L, nodeStats.getTotalEstimatedNativeBytes());
+            assertNotNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
+            assertEquals(10L, nodeStats.getAnalyticsBackendNativeMemoryStats().getAllocatedBytes());
+            assertNotNull(nodeStats.getNativeAllocatorStats());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemory_emptyObject() throws Exception {
+        final String json = "{\"name\":\"test-node\",\"timestamp\":111,\"native_memory\":{}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(-1L, nodeStats.getTotalEstimatedNativeBytes());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_blockCache_emptyObject() throws Exception {
+        final String json = "{\"name\":\"test-node\",\"timestamp\":111,\"block_cache\":{}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            final BlockCacheStats blockCache = nodeStats.getBlockCacheOnlyStats();
+            assertNotNull(blockCache);
+            assertEquals(0L, blockCache.hits());
+            assertEquals(0L, blockCache.misses());
+            assertEquals(0L, blockCache.evictionBytes());
+            assertEquals(0L, blockCache.removedBytes());
+            assertEquals(0L, blockCache.activeInBytes());
+            assertEquals(0L, blockCache.memoryBytesUsed());
+        }
+    }
+
     // ==================== Concurrent parsing test ====================
 
     @Test
@@ -1029,6 +1458,44 @@ class HttpNodesStatsActionTest {
         executor.shutdownNow();
         if (error.get() != null) {
             fail("Concurrent parsing failed: " + error.get().getMessage());
+        }
+    }
+
+    // ==================== getCurlRequest: detailed=true query param ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_getCurlRequest_fileCacheDetailed_true_addsDetailedParam() throws Exception {
+        final Settings settings = Settings.builder().putList("http.hosts", "localhost:9201").build();
+        try (final HttpClient httpClient = new HttpClient(settings, null)) {
+            final HttpNodesStatsAction nodesStatsAction = new HttpNodesStatsAction(httpClient, NodesStatsAction.INSTANCE);
+            final NodesStatsRequest request = new NodesStatsRequest();
+            request.fileCacheDetailed(true);
+            final CurlRequest curlRequest = nodesStatsAction.getCurlRequest(request);
+            final Field paramListField = CurlRequest.class.getDeclaredField("paramList");
+            paramListField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            final List<String> paramList = (List<String>) paramListField.get(curlRequest);
+            assertNotNull(paramList, "paramList must not be null when detailed=true is set");
+            assertTrue(paramList.contains("detailed=true"), "paramList must contain 'detailed=true', actual: " + paramList);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_getCurlRequest_fileCacheDetailed_false_omitsDetailedParam() throws Exception {
+        final Settings settings = Settings.builder().putList("http.hosts", "localhost:9201").build();
+        try (final HttpClient httpClient = new HttpClient(settings, null)) {
+            final HttpNodesStatsAction nodesStatsAction = new HttpNodesStatsAction(httpClient, NodesStatsAction.INSTANCE);
+            final NodesStatsRequest request = new NodesStatsRequest(); // default: fileCacheDetailed == false
+            final CurlRequest curlRequest = nodesStatsAction.getCurlRequest(request);
+            final Field paramListField = CurlRequest.class.getDeclaredField("paramList");
+            paramListField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            final List<String> paramList = (List<String>) paramListField.get(curlRequest);
+            // paramList may be null (no params set at all) or non-null but must not contain "detailed=true"
+            assertTrue(paramList == null || !paramList.contains("detailed=true"),
+                    "paramList must not contain 'detailed=true', actual: " + paramList);
         }
     }
 }


### PR DESCRIPTION
## Summary
Upgrade the OpenSearch dependency from 3.6.0 to 3.7.0, following the OpenSearch 3.7.0 release, bump the project version accordingly, and implement proper parsing for the node stats added in 3.7.0.

## Changes Made
- Bumped `opensearch.version` in `pom.xml` from 3.6.0 to 3.7.0
- Bumped the project version from 3.6.1-SNAPSHOT to 3.7.0-SNAPSHOT to track the OpenSearch version
- Bumped log4j from 2.25.3 to 2.25.4
- Updated the test container image version in `OpenSearch3ClientTest` from 3.5.0 to 3.7.0 (`public.ecr.aws/opensearchproject/opensearch:3.7.0`)
- Updated the dependency examples in README.md (Maven/Gradle) to 3.7.0
- Implemented parsing in `HttpNodesStatsAction` for the five `NodeStats` fields added in the OpenSearch 3.7.0 API (instead of passing `null`):
  - Parse the `native_memory` section (always present in 3.7.0 responses): `total_estimated_bytes` → `totalEstimatedNativeBytes`, `analytics_backend` → `AnalyticsBackendNativeMemoryStats`, and `native_allocator` (root + per-pool stats) → `NativeAllocatorPoolStats`
  - Support file cache detailed mode: when `NodesStatsRequest.isFileCacheDetailed()` (new in 3.7.0) is set, append `detailed=true` to the request URL and parse the resulting `file_cache` (`fileCacheOnlyStats`) and `block_cache` (`BlockCacheStats`) sections
  - When a section is absent (OpenSearch 1.x/2.x, Elasticsearch 7/8, or pre-3.7 servers), all values keep their previous defaults (`null` / `-1L`, the sentinel OpenSearch itself uses)
- Fixed a pre-existing dispatch bug: `fileCacheStats` is emitted under the `aggregate_file_cache` key (since 3.6.0), not `file_cache`, so it was silently skipped before; it is now parsed correctly

## Testing
- Confirmed that `org.opensearch:opensearch:3.7.0`, log4j 2.25.4, and the OpenSearch 3.7.0 image (ECR Public) are all available
- `mvn clean test-compile` passes against 3.7.0
- Added 18 unit tests to `HttpNodesStatsActionTest` (79 total, no Docker required) covering the new parsers (`native_memory`, `aggregate_file_cache`, detailed `file_cache`, `block_cache`), default preservation when sections are absent, unknown-field robustness, and the `detailed=true` query parameter
- Integration tests via Testcontainers against real containers: `OpenSearch3ClientTest` (73 tests) and `OpenSearch2ClientTest` (37 tests) — 110 tests, 0 failures, confirming both the new parsing on 3.7.0 and no regression on 2.x

## Breaking Changes
- None

## Additional Notes
- `BlockCacheStats` reconstruction is partial by design: the server's `toXContent` does not emit `hitBytes`, `missBytes`, eviction/removal counts, or the memory/disk usage split, so those record components are set to 0 (the combined `used_in_bytes` is assigned to `memoryBytesUsed` so re-serialization reproduces the same JSON value)
- The "Maven 3.6.0 or higher" mentions in README refer to the build tool requirement, not OpenSearch, and are intentionally unchanged
