### PR TITLE
build: sign artifacts in main build instead of release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,14 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<useReleaseProfile>false</useReleaseProfile>
+					<releaseProfiles>release</releaseProfiles>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
 				<version>0.10.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,10 +148,23 @@
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>3.1.1</version>
-				<configuration>
-					<useReleaseProfile>false</useReleaseProfile>
-					<releaseProfiles>release</releaseProfiles>
-				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>3.2.8</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+						<configuration>
+							<bestPractices>true</bestPractices>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
@@ -164,32 +177,6 @@
 			</plugin>
 		</plugins>
 	</build>
-	<profiles>
-		<profile>
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.8</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-								<configuration>
-									<bestPractices>true</bestPractices>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>


### PR DESCRIPTION
## Summary
Publishing to Maven Central via `mvn release:perform` failed with `Missing signature for file` errors for all artifacts (pom, jar, sources, javadoc). GPG signing was gated behind a `release` profile in #20, but nothing activated that profile during `release:perform`, so artifacts were uploaded unsigned.

Since the profile-based release mechanism (the super POM `release-profile` / `useReleaseProfile`) is deprecated and will be removed from Maven, this change drops the profile approach entirely instead of wiring the profile back in.

## Changes Made
- Remove the `release` profile and move maven-gpg-plugin (3.2.8, `bestPractices`) into the main `build/plugins`, matching the setup in other CodeLibs projects (e.g. opensearch-runner)
- Pin maven-release-plugin to 3.1.1

## Testing
- `mvn validate` passes
- Verified with `mvn help:effective-pom` that maven-gpg-plugin is bound to the `verify` phase in the main build and no profiles remain

## Additional Notes
- GPG signing now runs on any build that reaches the `verify` phase (`mvn install`/`verify`/`deploy`). CI is unaffected because the workflow runs `mvn -B package`, which stops before `verify`. Local builds without a GPG key can use `-Dgpg.skip=true`.
- Before re-releasing 3.7.0: drop the failed deployment in the Central Portal and delete the `fesen-httpclient-3.7.0` tag from the remote