### PR TITLE
docs: add Javadoc to all action classes and core client types

### DIFF
--- a/src/main/java/org/codelibs/fesen/client/EngineInfo.java
+++ b/src/main/java/org/codelibs/fesen/client/EngineInfo.java
@@ -17,6 +17,11 @@ package org.codelibs.fesen.client;
 
 import java.util.Map;
 
+/**
+ * Holds information about the backend search engine, such as the node name,
+ * cluster name, version number, and distribution, parsed from the root
+ * endpoint response of OpenSearch or Elasticsearch.
+ */
 public class EngineInfo {
 
     private static final String UNKNOWN = "unknown";
@@ -29,6 +34,12 @@ public class EngineInfo {
 
     private final String distribution;
 
+    /**
+     * Creates an engine information object from the parsed JSON content of the
+     * root endpoint response.
+     *
+     * @param content the parsed response body containing name, cluster_name, and version information
+     */
     public EngineInfo(final Map<String, Object> content) {
         nodeName = (String) content.getOrDefault("name", UNKNOWN);
         clusterName = (String) content.getOrDefault("cluster_name", UNKNOWN);
@@ -43,22 +54,47 @@ public class EngineInfo {
         }
     }
 
+    /**
+     * Returns the node name reported by the engine.
+     *
+     * @return the node name, or "unknown" if not available
+     */
     public String getNodeName() {
         return nodeName;
     }
 
+    /**
+     * Returns the cluster name reported by the engine.
+     *
+     * @return the cluster name, or "unknown" if not available
+     */
     public String getClusterName() {
         return clusterName;
     }
 
+    /**
+     * Returns the version number of the engine.
+     *
+     * @return the version number, or "unknown" if not available
+     */
     public String getNumber() {
         return number;
     }
 
+    /**
+     * Returns the distribution name of the engine, such as "elasticsearch" or "opensearch".
+     *
+     * @return the distribution name, or "unknown" if not available
+     */
     public String getDistribution() {
         return distribution;
     }
 
+    /**
+     * Determines the engine type from the distribution name and version number.
+     *
+     * @return the detected engine type, or {@link EngineType#UNKNOWN} if it cannot be determined
+     */
     public EngineType getType() {
         if (distribution.startsWith("elasticsearch")) {
             if (number.startsWith("7.")) {
@@ -81,7 +117,22 @@ public class EngineInfo {
         return EngineType.UNKNOWN;
     }
 
+    /**
+     * The type of the backend search engine, identified by its distribution
+     * and major version.
+     */
     public enum EngineType {
-        ELASTICSEARCH7, ELASTICSEARCH8, OPENSEARCH1, OPENSEARCH2, OPENSEARCH3, UNKNOWN;
+        /** Elasticsearch 7.x. */
+        ELASTICSEARCH7,
+        /** Elasticsearch 8.x. */
+        ELASTICSEARCH8,
+        /** OpenSearch 1.x. */
+        OPENSEARCH1,
+        /** OpenSearch 2.x. */
+        OPENSEARCH2,
+        /** OpenSearch 3.x. */
+        OPENSEARCH3,
+        /** An unknown or unsupported engine. */
+        UNKNOWN;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/HttpAbstractClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpAbstractClient.java
@@ -458,12 +458,20 @@ import org.opensearch.transport.client.OpenSearchClient;
  */
 public abstract class HttpAbstractClient implements Client {
 
+    /** Logger for this client instance. */
     protected final Logger logger;
 
+    /** Settings used to configure this client. */
     protected final Settings settings;
     private final ThreadPool threadPool;
     private final Admin admin;
 
+    /**
+     * Creates a new client instance.
+     *
+     * @param settings the settings used to configure this client
+     * @param threadPool the thread pool used by this client
+     */
     public HttpAbstractClient(final Settings settings, final ThreadPool threadPool) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -503,6 +511,15 @@ public abstract class HttpAbstractClient implements Client {
         doExecute(action, request, listener);
     }
 
+    /**
+     * Executes the given action against the backend. Subclasses implement the actual request handling.
+     *
+     * @param <Request> the request type
+     * @param <Response> the response type
+     * @param action the action to execute
+     * @param request the request to send
+     * @param listener the listener notified with the response or failure
+     */
     protected abstract <Request extends ActionRequest, Response extends ActionResponse> void doExecute(ActionType<Response> action,
             Request request, ActionListener<Response> listener);
 

--- a/src/main/java/org/codelibs/fesen/client/HttpAdminClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpAdminClient.java
@@ -19,10 +19,19 @@ import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.ClusterAdminClient;
 import org.opensearch.transport.client.IndicesAdminClient;
 
+/**
+ * An {@link AdminClient} wrapper that delegates to another admin client and wraps the indices
+ * admin client with {@link HttpIndicesAdminClient}.
+ */
 public class HttpAdminClient implements AdminClient {
 
     private final AdminClient adminClient;
 
+    /**
+     * Creates a new admin client wrapping the given delegate.
+     *
+     * @param admin the admin client to delegate to
+     */
     public HttpAdminClient(final AdminClient admin) {
         this.adminClient = admin;
     }

--- a/src/main/java/org/codelibs/fesen/client/HttpClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpClient.java
@@ -482,42 +482,68 @@ import org.opensearch.search.aggregations.pipeline.StatsBucketPipelineAggregatio
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
 
+/**
+ * An OpenSearch/Elasticsearch client implementation that communicates with the
+ * search engine over HTTP. It maps OpenSearch action types to HTTP-based action
+ * implementations and supports features such as basic authentication, SSL,
+ * compression, and HTTP proxies.
+ */
 public class HttpClient extends HttpAbstractClient {
 
+    /** A factory that creates a curl request using the HTTP GET method. */
     protected static final Function<String, CurlRequest> GET = Curl::get;
 
+    /** A factory that creates a curl request using the HTTP POST method. */
     protected static final Function<String, CurlRequest> POST = Curl::post;
 
+    /** A factory that creates a curl request using the HTTP PUT method. */
     protected static final Function<String, CurlRequest> PUT = Curl::put;
 
+    /** A factory that creates a curl request using the HTTP DELETE method. */
     protected static final Function<String, CurlRequest> DELETE = Curl::delete;
 
+    /** A factory that creates a curl request using the HTTP HEAD method. */
     protected static final Function<String, CurlRequest> HEAD = Curl::head;
 
+    /** The manager that tracks the availability of the configured engine nodes. */
     protected NodeManager nodeManager;
 
+    /** A mapping from action types to their HTTP-based action executors. */
     protected final Map<ActionType<?>, BiConsumer<ActionRequest, ActionListener<?>>> actions = new HashMap<>();
 
+    /** The registry of named XContent parsers used to parse responses. */
     protected final NamedXContentRegistry namedXContentRegistry;
 
+    /** The thread pool used to execute HTTP requests. */
     protected final ForkJoinPool threadPool;
 
+    /** The Basic authentication header value, or null if not configured. */
     protected final String basicAuth;
 
     private final SSLSocketFactory sslSocketFactory;
 
+    /** Whether gzip compression is enabled for HTTP requests. */
     protected final boolean compression;
 
+    /** The HTTP proxy to use for requests, or null if not configured. */
     protected final Proxy proxy;
 
+    /** The Proxy-Authorization header value, or null if not configured. */
     protected final String proxyAuth;
 
+    /** Operators applied to each curl request before it is sent, allowing request customization. */
     protected final List<UnaryOperator<CurlRequest>> requestBuilderList = new ArrayList<>();
 
     private EngineInfo engineInfo;
 
+    /**
+     * The content type of an HTTP request body.
+     */
     public enum ContentType {
-        JSON("application/json"), X_NDJSON("application/x-ndjson");
+        /** The application/json content type. */
+        JSON("application/json"),
+        /** The application/x-ndjson content type, used for bulk requests. */
+        X_NDJSON("application/x-ndjson");
 
         private final String value;
 
@@ -525,15 +551,35 @@ public class HttpClient extends HttpAbstractClient {
             this.value = value;
         }
 
+        /**
+         * Returns the MIME type string of this content type.
+         *
+         * @return the MIME type string
+         */
         public String getString() {
             return this.value;
         }
     }
 
+    /**
+     * Creates a new HTTP client with the given settings and thread pool.
+     *
+     * @param settings the client settings, including http.hosts and authentication options
+     * @param threadPool the thread pool passed to the underlying client
+     */
     public HttpClient(final Settings settings, final ThreadPool threadPool) {
         this(settings, threadPool, Collections.emptyList());
     }
 
+    /**
+     * Creates a new HTTP client with the given settings, thread pool, and
+     * additional named XContent entries used to parse responses.
+     *
+     * @param settings the client settings, including http.hosts and authentication options
+     * @param threadPool the thread pool passed to the underlying client
+     * @param namedXContentEntries additional named XContent entries to register
+     * @throws OpenSearchException if http.hosts is empty
+     */
     public HttpClient(final Settings settings, final ThreadPool threadPool, final List<NamedXContentRegistry.Entry> namedXContentEntries) {
         super(settings, threadPool);
         final String[] hosts = settings.getAsList("http.hosts").stream().map(s -> {
@@ -1106,6 +1152,13 @@ public class HttpClient extends HttpAbstractClient {
         return new HttpAdminClient(super.admin());
     }
 
+    /**
+     * Returns information about the backend engine by accessing the root
+     * endpoint. The result is cached after the first successful call.
+     *
+     * @return the engine information
+     * @throws OpenSearchException if the engine information cannot be retrieved
+     */
     public EngineInfo getEngineInfo() {
         if (engineInfo != null) {
             return engineInfo;
@@ -1135,6 +1188,13 @@ public class HttpClient extends HttpAbstractClient {
         throw new OpenSearchException("Unknown server info: {}", nodeManager.toNodeString());
     }
 
+    /**
+     * Creates a Basic authentication header value from the fesen.username and
+     * fesen.password settings.
+     *
+     * @param settings the client settings
+     * @return the Basic authentication header value, or null if the username or password is not set
+     */
     protected String createBasicAuthentication(final Settings settings) {
         final String username = settings.get("fesen.username");
         final String password = settings.get("fesen.password");
@@ -1145,6 +1205,13 @@ public class HttpClient extends HttpAbstractClient {
         return null;
     }
 
+    /**
+     * Creates an SSL socket factory that trusts the certificate specified by
+     * the http.ssl.certificate_authorities setting.
+     *
+     * @param settings the client settings
+     * @return the SSL socket factory, or null if the setting is not configured or the certificate cannot be loaded
+     */
     protected SSLSocketFactory createSSLSocketFactory(final Settings settings) {
         final String certificateAuthorities = settings.get("http.ssl.certificate_authorities");
         if (logger.isDebugEnabled()) {
@@ -1172,6 +1239,13 @@ public class HttpClient extends HttpAbstractClient {
         return null;
     }
 
+    /**
+     * Creates an HTTP proxy from the https.proxy_host/https.proxy_port or
+     * http.proxy_host/http.proxy_port settings.
+     *
+     * @param settings the client settings
+     * @return the proxy, or null if the proxy host or port is not configured
+     */
     protected Proxy createProxy(final Settings settings) {
         final String host = getFromSettings(settings, "https.proxy_host", "http.proxy_host");
         final String port = getFromSettings(settings, "https.proxy_port", "http.proxy_port");
@@ -1181,6 +1255,14 @@ public class HttpClient extends HttpAbstractClient {
         return null;
     }
 
+    /**
+     * Creates a Proxy-Authorization header value from the
+     * https.proxy_username/https.proxy_password or
+     * http.proxy_username/http.proxy_password settings.
+     *
+     * @param settings the client settings
+     * @return the proxy authentication header value, or null if the username or password is not set
+     */
     protected String createProxyAuthentication(final Settings settings) {
         final String username = getFromSettings(settings, "https.proxy_username", "http.proxy_username");
         final String password = getFromSettings(settings, "https.proxy_password", "http.proxy_password");
@@ -1191,6 +1273,15 @@ public class HttpClient extends HttpAbstractClient {
         return null;
     }
 
+    /**
+     * Returns the value of the first setting key if present, otherwise the
+     * value of the second setting key.
+     *
+     * @param settings the client settings
+     * @param key1 the preferred setting key
+     * @param key2 the fallback setting key
+     * @return the setting value, or null if neither key is set
+     */
     protected String getFromSettings(final Settings settings, final String key1, final String key2) {
         final String value1 = settings.get(key1);
         if (value1 != null) {
@@ -1237,15 +1328,45 @@ public class HttpClient extends HttpAbstractClient {
         httpAction.accept(request, listener);
     }
 
+    /**
+     * Creates a curl request for the given HTTP method, path, and indices,
+     * using the JSON content type.
+     *
+     * @param method the factory that creates a curl request for an HTTP method
+     * @param path the request path appended after the indices
+     * @param indices the target index names
+     * @return the configured curl request
+     */
     public CurlRequest getCurlRequest(final Function<String, CurlRequest> method, final String path, final String... indices) {
         return getCurlRequest(method, ContentType.JSON, path, indices);
     }
 
+    /**
+     * Creates a curl request for the given HTTP method, content type, path,
+     * and indices. The request is bound to the node manager for failover.
+     *
+     * @param method the factory that creates a curl request for an HTTP method
+     * @param contentType the content type of the request body
+     * @param path the request path appended after the indices
+     * @param indices the target index names
+     * @return the configured curl request
+     */
     public CurlRequest getCurlRequest(final Function<String, CurlRequest> method, final ContentType contentType, final String path,
             final String... indices) {
         return getPlainCurlRequest(s -> new FesenRequest(method.apply(null), nodeManager, s), contentType, path, indices);
     }
 
+    /**
+     * Creates a curl request from the given request creator and applies the
+     * configured options such as content type, authentication, SSL,
+     * compression, proxy, and registered request builders.
+     *
+     * @param requestCreator the function that creates a curl request from the built path
+     * @param contentType the content type of the request body
+     * @param path the request path appended after the indices
+     * @param indices the target index names
+     * @return the configured curl request
+     */
     public CurlRequest getPlainCurlRequest(final Function<String, CurlRequest> requestCreator, final ContentType contentType,
             final String path, final String... indices) {
         final StringBuilder buf = new StringBuilder(100);
@@ -1277,6 +1398,14 @@ public class HttpClient extends HttpAbstractClient {
         return request;
     }
 
+    /**
+     * Creates the thread pool used to execute HTTP requests. The parallelism
+     * is taken from the thread_pool.http.size or processors setting, and the
+     * async mode from the thread_pool.http.async setting.
+     *
+     * @param settings the client settings
+     * @return the created thread pool
+     */
     protected ForkJoinPool createThreadPool(final Settings settings) {
         final int parallelism =
                 settings.getAsInt("thread_pool.http.size", settings.getAsInt("processors", Runtime.getRuntime().availableProcessors()));
@@ -1285,6 +1414,12 @@ public class HttpClient extends HttpAbstractClient {
                 asyncMode);
     }
 
+    /**
+     * Returns the default named XContent entries used to parse aggregation
+     * responses.
+     *
+     * @return the default named XContent entries
+     */
     protected List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
         // SearchModule.getNamedXContents() requires too many dependencies to instantiate.
         // Maintain the aggregation parser mappings manually.
@@ -1343,6 +1478,12 @@ public class HttpClient extends HttpAbstractClient {
                 .toList();
     }
 
+    /**
+     * Returns the named XContent entries provided by
+     * {@link NamedXContentProvider} services discovered via the service loader.
+     *
+     * @return the named XContent entries from service providers
+     */
     protected List<NamedXContentRegistry.Entry> getProvidedNamedXContents() {
         final List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
         for (final NamedXContentProvider service : ServiceLoader.load(NamedXContentProvider.class)) {
@@ -1351,15 +1492,33 @@ public class HttpClient extends HttpAbstractClient {
         return entries;
     }
 
+    /**
+     * Returns the registry of named XContent parsers used by this client.
+     *
+     * @return the named XContent registry
+     */
     public NamedXContentRegistry getNamedXContentRegistry() {
         return namedXContentRegistry;
     }
 
+    /**
+     * Adds an operator that customizes each curl request before it is sent.
+     *
+     * @param builder the operator applied to each curl request
+     */
     public void addRequestBuilder(final UnaryOperator<CurlRequest> builder) {
         requestBuilderList.add(builder);
     }
 
+    /**
+     * A worker thread for the HTTP request thread pool, named "eshttp".
+     */
     protected static class WorkerThread extends ForkJoinWorkerThread {
+        /**
+         * Creates a new worker thread for the given pool.
+         *
+         * @param pool the fork-join pool this thread works in
+         */
         protected WorkerThread(final ForkJoinPool pool) {
             super(pool);
             setName("eshttp");

--- a/src/main/java/org/codelibs/fesen/client/HttpIndicesAdminClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpIndicesAdminClient.java
@@ -124,10 +124,20 @@ import org.opensearch.core.action.ActionResponse;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.IndicesAdminClient;
 
+/**
+ * An {@link IndicesAdminClient} implementation that delegates all indices
+ * administration operations to a wrapped client, overriding selected request
+ * builders (such as index creation) with HTTP-based implementations.
+ */
 public class HttpIndicesAdminClient implements IndicesAdminClient {
 
     private final IndicesAdminClient indicesClient;
 
+    /**
+     * Creates a new instance that delegates to the given indices admin client.
+     *
+     * @param indices the indices admin client to delegate operations to
+     */
     public HttpIndicesAdminClient(final IndicesAdminClient indices) {
         this.indicesClient = indices;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpAction.java
@@ -37,94 +37,153 @@ import org.opensearch.core.xcontent.XContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.BytesRestResponse;
 
+/**
+ * Base class for HTTP-based action implementations that invoke OpenSearch/Elasticsearch
+ * REST APIs. Provides shared parse fields, HTTP method factories, and helper methods for
+ * parsing responses and converting errors to exceptions.
+ */
 public class HttpAction {
 
+    /** Parse field for the "shard" response property. */
     protected static final ParseField SHARD_FIELD = new ParseField("shard");
 
+    /** Parse field for the "index" response property. */
     protected static final ParseField INDEX_FIELD = new ParseField("index");
 
+    /** Parse field for the "query" response property. */
     protected static final ParseField QUERY_FIELD = new ParseField("query");
 
+    /** Parse field for the "reason" response property. */
     protected static final ParseField REASON_FIELD = new ParseField("reason");
 
+    /** Parse field for the "aliases" response property. */
     protected static final ParseField ALIASES_FIELD = new ParseField("aliases");
 
+    /** Parse field for the "mappings" response property. */
     protected static final ParseField MAPPINGS_FIELD = new ParseField("mappings");
 
+    /** Parse field for the "type" response property. */
     protected static final ParseField TYPE_FIELD = new ParseField("type");
 
+    /** Parse field for the "details" response property. */
     protected static final ParseField DETAILS_FIELD = new ParseField("details");
 
+    /** Parse field for the "_shards" response property. */
     protected static final ParseField _SHARDS_FIELD = new ParseField("_shards");
 
+    /** Parse field for the "tasks" response property. */
     protected static final ParseField TASKS_FIELD = new ParseField("tasks");
 
+    /** Parse field for the "insert_order" response property. */
     protected static final ParseField INSERT_ORDER_FIELD = new ParseField("insert_order");
 
+    /** Parse field for the "priority" response property. */
     protected static final ParseField PRIORITY_FIELD = new ParseField("priority");
 
+    /** Parse field for the "source" response property. */
     protected static final ParseField SOURCE_FIELD = new ParseField("source");
 
+    /** Parse field for the "time_in_queue_millis" response property. */
     protected static final ParseField TIME_IN_QUEUE_MILLIS_FIELD = new ParseField("time_in_queue_millis");
 
+    /** Parse field for the "time_in_execution_millis" response property. */
     protected static final ParseField TIME_IN_EXECUTION_MILLIS_FIELD = new ParseField("time_in_execution_millis");
 
+    /** Parse field for the "executing" response property. */
     protected static final ParseField EXECUTING_FIELD = new ParseField("executing");
 
+    /** Parse field for the "total" response property. */
     protected static final ParseField TOTAL_FIELD = new ParseField("total");
 
+    /** Parse field for the "successful" response property. */
     protected static final ParseField SUCCESSFUL_FIELD = new ParseField("successful");
 
+    /** Parse field for the "failed" response property. */
     protected static final ParseField FAILED_FIELD = new ParseField("failed");
 
+    /** Parse field for the "failures" response property. */
     protected static final ParseField FAILURES_FIELD = new ParseField("failures");
 
+    /** Parse field for the "state" response property. */
     protected static final ParseField STATE_FIELD = new ParseField("state");
 
+    /** Parse field for the "primary" response property. */
     protected static final ParseField PRIMARY_FIELD = new ParseField("primary");
 
+    /** Parse field for the "node" response property. */
     protected static final ParseField NODE_FIELD = new ParseField("node");
 
+    /** Parse field for the "relocating_node" response property. */
     protected static final ParseField RELOCATING_NODE_FIELD = new ParseField("relocating_node");
 
+    /** Parse field for the "expected_shard_size_in_bytes" response property. */
     protected static final ParseField EXPECTED_SHARD_SIZE_IN_BYTES_FIELD = new ParseField("expected_shard_size_in_bytes");
 
+    /** Parse field for the "routing" response property. */
     protected static final ParseField ROUTING_FIELD = new ParseField("routing");
 
+    /** Parse field for the "full_name" response property. */
     protected static final ParseField FULL_NAME_FIELD = new ParseField("full_name");
 
+    /** Parse field for the "mapping" response property. */
     protected static final ParseField MAPPING_FIELD = new ParseField("mapping");
 
+    /** Parse field for the "unassigned_info" response property. */
     protected static final ParseField UNASSIGNED_INFO_FIELD = new ParseField("unassigned_info");
 
+    /** Parse field for the "allocation_id" response property. */
     protected static final ParseField ALLOCATION_ID_FIELD = new ParseField("allocation_id");
 
+    /** Parse field for the "recovery_source" response property. */
     protected static final ParseField RECOVERY_SOURCE_FIELD = new ParseField("recovery_source");
 
+    /** Parse field for the "at" response property. */
     protected static final ParseField AT_FIELD = new ParseField("at");
 
+    /** Parse field for the "failed_attempts" response property. */
     protected static final ParseField FAILED_ATTEMPTS_FIELD = new ParseField("failed_attempts");
 
+    /** Parse field for the "allocation_status" response property. */
     protected static final ParseField ALLOCATION_STATUS_FIELD = new ParseField("allocation_status");
 
+    /** Parse field for the "delayed" response property. */
     protected static final ParseField DELAYED_FIELD = new ParseField("delayed");
 
+    /** Factory that creates a GET request for a URL. */
     protected static final Function<String, CurlRequest> GET = Curl::get;
 
+    /** Factory that creates a POST request for a URL. */
     protected static final Function<String, CurlRequest> POST = Curl::post;
 
+    /** Factory that creates a PUT request for a URL. */
     protected static final Function<String, CurlRequest> PUT = Curl::put;
 
+    /** Factory that creates a DELETE request for a URL. */
     protected static final Function<String, CurlRequest> DELETE = Curl::delete;
 
+    /** Factory that creates a HEAD request for a URL. */
     protected static final Function<String, CurlRequest> HEAD = Curl::head;
 
+    /** The HTTP client used to send requests. */
     protected final HttpClient client;
 
+    /**
+     * Creates a new action bound to the given HTTP client.
+     *
+     * @param client the HTTP client used to send requests
+     */
     public HttpAction(final HttpClient client) {
         this.client = client;
     }
 
+    /**
+     * Creates an XContent parser for the body of the given HTTP response, choosing the
+     * content type from the response's Content-Type header.
+     *
+     * @param response the HTTP response to parse
+     * @return a parser over the response body
+     * @throws IOException if the parser cannot be created
+     */
     protected XContentParser createParser(final CurlResponse response) throws IOException {
         final String contentType = response.getHeaderValue("Content-Type");
         final MediaType mediaType = fromMediaTypeOrFormat(contentType);
@@ -132,6 +191,14 @@ public class HttpAction {
         return xContent.createParser(client.getNamedXContentRegistry(), LoggingDeprecationHandler.INSTANCE, response.getContentAsStream());
     }
 
+    /**
+     * Converts an error HTTP response into an {@link OpenSearchStatusException}, parsing the
+     * error body if possible and falling back to the raw content and HTTP status code.
+     *
+     * @param response the HTTP response containing the error
+     * @param t the original throwable to attach as a suppressed exception
+     * @return the exception describing the error response
+     */
     protected OpenSearchStatusException toOpenSearchException(final CurlResponse response, final Throwable t) {
         OpenSearchStatusException fesenException;
         try (final XContentParser parser = createParser(response)) {
@@ -147,6 +214,14 @@ public class HttpAction {
         return fesenException;
     }
 
+    /**
+     * Notifies the listener of a failure, unwrapping the cause if it is an
+     * {@link OpenSearchException}.
+     *
+     * @param <T> the response type of the listener
+     * @param listener the listener to notify
+     * @param e the exception that occurred
+     */
     protected <T> void unwrapOpenSearchException(final ActionListener<T> listener, final Exception e) {
         if (e.getCause() instanceof OpenSearchException) {
             listener.onFailure((OpenSearchException) e.getCause());
@@ -155,6 +230,12 @@ public class HttpAction {
         }
     }
 
+    /**
+     * Extracts the numeric value from an {@link ActiveShardCount} via its serialized form.
+     *
+     * @param activeShardCount the active shard count to convert
+     * @return the numeric active shard count value
+     */
     protected int getActiveShardsCountValue(final ActiveShardCount activeShardCount) {
         try (final ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
             activeShardCount.writeTo(out);
@@ -164,6 +245,10 @@ public class HttpAction {
         }
     }
 
+    /**
+     * Exception that carries the raw content of an HTTP response, attached as a suppressed
+     * exception for diagnostic purposes.
+     */
     protected static class CurlResponseException extends Exception {
         private static final long serialVersionUID = 1L;
 
@@ -172,6 +257,13 @@ public class HttpAction {
         }
     }
 
+    /**
+     * Resolves a media type string (such as a Content-Type header value) to a known
+     * {@link XContentType}, defaulting to JSON if no match is found.
+     *
+     * @param mediaType the media type string, may be {@code null}
+     * @return the matching media type, or JSON if none matches
+     */
     protected static MediaType fromMediaTypeOrFormat(final String mediaType) {
         if (mediaType != null) {
             for (final XContentType type : XContentType.values()) {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpAnalyzeAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpAnalyzeAction.java
@@ -42,15 +42,32 @@ import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Analyze API over HTTP for OpenSearch/Elasticsearch, performing text
+ * analysis with analyzers, tokenizers, and filters.
+ */
 public class HttpAnalyzeAction extends HttpAction {
 
+    /** The analyze action definition. */
     protected final AnalyzeAction action;
 
+    /**
+     * Creates a new HTTP analyze action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the analyze action definition
+     */
     public HttpAnalyzeAction(final HttpClient client, final AnalyzeAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the analyze request and notifies the listener with the response.
+     *
+     * @param request the analyze request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final AnalyzeAction.Request request, final ActionListener<AnalyzeAction.Response> listener) {
         String source = null;
         try (final XContentBuilder builder = toXContent(request, JsonXContent.contentBuilder())) {
@@ -69,10 +86,24 @@ public class HttpAnalyzeAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the analyze API endpoint.
+     *
+     * @param request the analyze request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final AnalyzeAction.Request request) {
         return client.getCurlRequest(POST, "/_analyze", request.index() == null ? new String[0] : request.indices());
     }
 
+    /**
+     * Serializes the analyze request to XContent for use as a request body.
+     *
+     * @param request the analyze request
+     * @param builder the builder to write to
+     * @return the builder with the serialized request
+     * @throws IOException if writing to the builder fails
+     */
     protected XContentBuilder toXContent(final AnalyzeAction.Request request, final XContentBuilder builder) throws IOException {
         builder.startObject();
         builder.field("text", request.text());
@@ -166,10 +197,25 @@ public class HttpAnalyzeAction extends HttpAction {
         PARSER.declareObject(optionalConstructorArg(), DETAIL_PARSER, new ParseField(Fields.DETAIL));
     }
 
+    /**
+     * Parses an analyze response from XContent.
+     *
+     * @param parser the parser positioned at the response
+     * @return the parsed analyze response
+     * @throws IOException if parsing fails
+     */
     public static AnalyzeAction.Response fromXContent(final XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
     }
 
+    /**
+     * Parses a single analyze token object from XContent, collecting unknown fields as
+     * token attributes.
+     *
+     * @param parser the parser positioned at the token object
+     * @return the parsed analyze token
+     * @throws IOException if parsing fails
+     */
     protected static AnalyzeToken getAnalyzeTokenFromXContent(final XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         String field = null;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpBulkAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpBulkAction.java
@@ -55,6 +55,10 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.seqno.SequenceNumbers;
 
+/**
+ * Handles the Bulk API over HTTP for OpenSearch/Elasticsearch, executing multiple
+ * index, create, update, and delete operations in a single request.
+ */
 public class HttpBulkAction extends HttpAction {
 
     private static final String ITEMS = "items";
@@ -64,13 +68,26 @@ public class HttpBulkAction extends HttpAction {
     private static final String STATUS = "status";
     private static final String ERROR = "error";
 
+    /** The bulk action definition. */
     protected final BulkAction action;
 
+    /**
+     * Creates a new HTTP bulk action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the bulk action definition
+     */
     public HttpBulkAction(final HttpClient client, final BulkAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the bulk request and notifies the listener with the response.
+     *
+     * @param request the bulk request containing the document write operations
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final BulkRequest request, final ActionListener<BulkResponse> listener) {
         // http://ndjson.org/
         final StringBuilder buf = new StringBuilder(10000);
@@ -120,6 +137,13 @@ public class HttpBulkAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a bulk response from XContent.
+     *
+     * @param parser the parser positioned at the response
+     * @return the parsed bulk response
+     * @throws IOException if parsing fails
+     */
     // BulkResponse.fromXContent(parser)
     protected BulkResponse fromXContent(final XContentParser parser) throws IOException {
         XContentParser.Token token = parser.nextToken();
@@ -156,6 +180,14 @@ public class HttpBulkAction extends HttpAction {
         return new BulkResponse(items.toArray(new BulkItemResponse[items.size()]), took, ingestTook);
     }
 
+    /**
+     * Parses a single bulk item response from XContent.
+     *
+     * @param parser the parser positioned at the item object
+     * @param id the position of the item within the bulk response
+     * @return the parsed bulk item response
+     * @throws IOException if parsing fails
+     */
     // BulkItemResponse.fromXContent(parser, items.size()))
     protected BulkItemResponse fromXContent(final XContentParser parser, final int id) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -224,6 +256,12 @@ public class HttpBulkAction extends HttpAction {
         return bulkItemResponse;
     }
 
+    /**
+     * Builds the HTTP request for the bulk API endpoint.
+     *
+     * @param request the bulk request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final BulkRequest request) {
         // RestBulkAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_bulk");
@@ -239,6 +277,13 @@ public class HttpBulkAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Builds the NDJSON action line (such as {@code {"index":{...}}}) for a document
+     * write request in the bulk request body.
+     *
+     * @param request the document write request
+     * @return the JSON action line for the request
+     */
     protected String getStringfromDocWriteRequest(final DocWriteRequest<?> request) {
         // BulkRequestParser
         final StringBuilder buf = new StringBuilder(100);
@@ -289,10 +334,26 @@ public class HttpBulkAction extends HttpAction {
         return buf.toString();
     }
 
+    /**
+     * Appends a JSON key/value pair with a numeric value to the buffer.
+     *
+     * @param buf the buffer to append to
+     * @param key the JSON key
+     * @param value the numeric value
+     * @return the buffer for chaining
+     */
     protected StringBuilder appendStr(final StringBuilder buf, final String key, final long value) {
         return buf.append('"').append(key).append("\":").append(value);
     }
 
+    /**
+     * Appends a JSON key/value pair with a string value to the buffer.
+     *
+     * @param buf the buffer to append to
+     * @param key the JSON key
+     * @param value the string value
+     * @return the buffer for chaining
+     */
     protected StringBuilder appendStr(final StringBuilder buf, final String key, final String value) {
         return buf.append('"').append(key).append("\":\"").append(value).append('"');
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCancelTasksAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCancelTasksAction.java
@@ -23,15 +23,32 @@ import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Cancel Tasks API over HTTP for OpenSearch/Elasticsearch, cancelling
+ * tasks running on cluster nodes.
+ */
 public class HttpCancelTasksAction extends HttpAction {
 
+    /** The cancel tasks action definition. */
     protected final CancelTasksAction action;
 
+    /**
+     * Creates a new HTTP cancel tasks action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the cancel tasks action definition
+     */
     public HttpCancelTasksAction(final HttpClient client, final CancelTasksAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cancel tasks request and notifies the listener with the response.
+     *
+     * @param request the cancel tasks request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CancelTasksRequest request, final ActionListener<CancelTasksResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +60,12 @@ public class HttpCancelTasksAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the cancel tasks API endpoint.
+     *
+     * @param request the cancel tasks request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final CancelTasksRequest request) {
         // RestCancelTasksAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_tasks/_cancel");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClearIndicesCacheAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClearIndicesCacheAction.java
@@ -23,15 +23,32 @@ import org.opensearch.action.admin.indices.cache.clear.ClearIndicesCacheResponse
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Clear Indices Cache API over HTTP for OpenSearch/Elasticsearch, clearing
+ * field data, query, and request caches for indices.
+ */
 public class HttpClearIndicesCacheAction extends HttpAction {
 
+    /** The clear indices cache action definition. */
     protected final ClearIndicesCacheAction action;
 
+    /**
+     * Creates a new HTTP clear indices cache action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the clear indices cache action definition
+     */
     public HttpClearIndicesCacheAction(final HttpClient client, final ClearIndicesCacheAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the clear indices cache request and notifies the listener with the response.
+     *
+     * @param request the clear indices cache request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClearIndicesCacheRequest request, final ActionListener<ClearIndicesCacheResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +60,12 @@ public class HttpClearIndicesCacheAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the clear indices cache API endpoint.
+     *
+     * @param request the clear indices cache request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final ClearIndicesCacheRequest request) {
         // RestClearIndicesCacheAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_cache/clear", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClearScrollAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClearScrollAction.java
@@ -29,15 +29,32 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Clear Scroll API over HTTP for OpenSearch/Elasticsearch, releasing
+ * search contexts held by scroll requests.
+ */
 public class HttpClearScrollAction extends HttpAction {
 
+    /** The clear scroll action definition. */
     protected final ClearScrollAction action;
 
+    /**
+     * Creates a new HTTP clear scroll action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the clear scroll action definition
+     */
     public HttpClearScrollAction(final HttpClient client, final ClearScrollAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the clear scroll request and notifies the listener with the response.
+     *
+     * @param request the clear scroll request containing the scroll IDs to release
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClearScrollRequest request, final ActionListener<ClearScrollResponse> listener) {
         String source = null;
         try (final XContentBuilder builder =
@@ -57,6 +74,12 @@ public class HttpClearScrollAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the clear scroll API endpoint.
+     *
+     * @param request the clear scroll request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final ClearScrollRequest request) {
         return client.getCurlRequest(DELETE, "/_search/scroll");
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCloseIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCloseIndexAction.java
@@ -33,15 +33,32 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Close Index API over HTTP for OpenSearch/Elasticsearch, closing one or
+ * more indices.
+ */
 public class HttpCloseIndexAction extends HttpAction {
 
+    /** The close index action definition. */
     protected final CloseIndexAction action;
 
+    /**
+     * Creates a new HTTP close index action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the close index action definition
+     */
     public HttpCloseIndexAction(final HttpClient client, final CloseIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the close index request and notifies the listener with the response.
+     *
+     * @param request the close index request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CloseIndexRequest request, final ActionListener<CloseIndexResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -53,6 +70,12 @@ public class HttpCloseIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the close index API endpoint.
+     *
+     * @param request the close index request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final CloseIndexRequest request) {
         // RestCloseIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_close", request.indices());
@@ -65,6 +88,13 @@ public class HttpCloseIndexAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Parses a close index response from XContent.
+     *
+     * @param parser the parser positioned at the response
+     * @return the parsed close index response
+     * @throws IOException if parsing fails
+     */
     protected CloseIndexResponse fromXContent(final XContentParser parser) throws IOException {
         List<IndexResult> indices = Collections.emptyList();
         boolean shardsAcknowledged = false;
@@ -91,6 +121,13 @@ public class HttpCloseIndexAction extends HttpAction {
         return new CloseIndexResponse(acknowledged, shardsAcknowledged, indices);
     }
 
+    /**
+     * Parses the "indices" object of a close index response into a list of index results.
+     *
+     * @param parser the parser positioned at the indices object
+     * @return the parsed index results
+     * @throws IOException if parsing fails
+     */
     protected List<IndexResult> parseIndices(final XContentParser parser) throws IOException {
         final List<IndexResult> list = new ArrayList<>();
         String fieldName = null;
@@ -107,6 +144,14 @@ public class HttpCloseIndexAction extends HttpAction {
         return list;
     }
 
+    /**
+     * Parses the result for a single index from a close index response.
+     *
+     * @param parser the parser positioned at the index result object
+     * @param index the name of the index
+     * @return the parsed index result
+     * @throws IOException if parsing fails
+     */
     protected IndexResult parseIndexResult(final XContentParser parser, final String index) throws IOException {
         boolean closed = false;
         OpenSearchException eex = null;
@@ -142,6 +187,13 @@ public class HttpCloseIndexAction extends HttpAction {
         return new IndexResult(idx);
     }
 
+    /**
+     * Parses the "failedShards" object of an index result into a list of shard results.
+     *
+     * @param parser the parser positioned at the failed shards object
+     * @return the parsed shard results
+     * @throws IOException if parsing fails
+     */
     protected List<ShardResult> parseShardResults(final XContentParser parser) throws IOException {
         final List<ShardResult> list = new ArrayList<>();
         String fieldName = null;
@@ -158,6 +210,15 @@ public class HttpCloseIndexAction extends HttpAction {
         return list;
     }
 
+    /**
+     * Parses the result for a single shard, including its failures, from a close index
+     * response.
+     *
+     * @param parser the parser positioned at the shard result object
+     * @param id the shard ID
+     * @return the parsed shard result
+     * @throws IOException if parsing fails
+     */
     protected ShardResult parseShardResult(final XContentParser parser, final int id) throws IOException {
         final List<Failure> failures = new ArrayList<>();
         String fieldName = null;
@@ -176,6 +237,13 @@ public class HttpCloseIndexAction extends HttpAction {
         return new ShardResult(id, failures.toArray(new Failure[failures.size()]));
     }
 
+    /**
+     * Parses a single shard failure from a close index response.
+     *
+     * @param parser the parser positioned at the failure object
+     * @return the parsed failure
+     * @throws IOException if parsing fails
+     */
     protected Failure parseFailure(final XContentParser parser) throws IOException {
         int shardId = -1;
         String index = null;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterAllocationExplainAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterAllocationExplainAction.java
@@ -40,15 +40,33 @@ import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Cluster Allocation Explain API over HTTP for OpenSearch/Elasticsearch,
+ * explaining why a shard is or is not allocated to a node.
+ */
 public class HttpClusterAllocationExplainAction extends HttpAction {
 
+    /** The cluster allocation explain action definition. */
     protected final ClusterAllocationExplainAction action;
 
+    /**
+     * Creates a new HTTP cluster allocation explain action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the cluster allocation explain action definition
+     */
     public HttpClusterAllocationExplainAction(final HttpClient client, final ClusterAllocationExplainAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster allocation explain request and notifies the listener with the
+     * response.
+     *
+     * @param request the cluster allocation explain request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterAllocationExplainRequest request, final ActionListener<ClusterAllocationExplainResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -60,6 +78,14 @@ public class HttpClusterAllocationExplainAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a cluster allocation explain response from XContent, extracting the index,
+     * shard, primary flag, and current node information.
+     *
+     * @param parser the parser positioned at the response
+     * @return the parsed cluster allocation explain response
+     * @throws IOException if parsing fails
+     */
     protected ClusterAllocationExplainResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         String index = "";
@@ -129,6 +155,12 @@ public class HttpClusterAllocationExplainAction extends HttpAction {
         return new ClusterAllocationExplainResponse(explanation);
     }
 
+    /**
+     * Skips the current object or array in the parser, consuming all nested tokens.
+     *
+     * @param parser the parser positioned inside the object or array to skip
+     * @throws IOException if reading from the parser fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -142,6 +174,13 @@ public class HttpClusterAllocationExplainAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the HTTP request for the cluster allocation explain API endpoint, using POST
+     * with a request body when an index is specified and GET otherwise.
+     *
+     * @param request the cluster allocation explain request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final ClusterAllocationExplainRequest request) {
         final CurlRequest curlRequest;
         if (request.getIndex() != null) {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterHealthAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterHealthAction.java
@@ -44,15 +44,32 @@ import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Cluster Health API over HTTP for OpenSearch/Elasticsearch, retrieving
+ * the health status of the cluster and its indices.
+ */
 public class HttpClusterHealthAction extends HttpAction {
 
+    /** The cluster health action definition. */
     protected final ClusterHealthAction action;
 
+    /**
+     * Creates a new HTTP cluster health action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the cluster health action definition
+     */
     public HttpClusterHealthAction(final HttpClient client, final ClusterHealthAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster health request and notifies the listener with the response.
+     *
+     * @param request the cluster health request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterHealthRequest request, final ActionListener<ClusterHealthResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -64,6 +81,12 @@ public class HttpClusterHealthAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the cluster health API endpoint.
+     *
+     * @param request the cluster health request
+     * @return the HTTP request to execute
+     */
     protected CurlRequest getCurlRequest(final ClusterHealthRequest request) {
         // RestClusterHealthAction
         final CurlRequest curlRequest = client.getCurlRequest(GET,

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterRerouteAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterRerouteAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the cluster reroute API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpClusterRerouteAction extends HttpAction {
 
+    /** The cluster reroute action. */
     protected final ClusterRerouteAction action;
 
+    /**
+     * Creates a new HTTP cluster reroute action.
+     *
+     * @param client the HTTP client
+     * @param action the cluster reroute action
+     */
     public HttpClusterRerouteAction(final HttpClient client, final ClusterRerouteAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster reroute request asynchronously.
+     *
+     * @param request the cluster reroute request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterRerouteRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpClusterRerouteAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the cluster reroute API.
+     *
+     * @param request the cluster reroute request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ClusterRerouteRequest request) {
         // RestClusterRerouteAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_cluster/reroute");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterSearchShardsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterSearchShardsAction.java
@@ -29,15 +29,31 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the cluster search shards API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpClusterSearchShardsAction extends HttpAction {
 
+    /** The cluster search shards action. */
     protected final ClusterSearchShardsAction action;
 
+    /**
+     * Creates a new HTTP cluster search shards action.
+     *
+     * @param client the HTTP client
+     * @param action the cluster search shards action
+     */
     public HttpClusterSearchShardsAction(final HttpClient client, final ClusterSearchShardsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster search shards request asynchronously.
+     *
+     * @param request the cluster search shards request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterSearchShardsRequest request, final ActionListener<ClusterSearchShardsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -49,6 +65,15 @@ public class HttpClusterSearchShardsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a cluster search shards response from the given parser. The response body is consumed
+     * and a response with empty groups, nodes, and alias filters is returned because the internal
+     * structures cannot be reconstructed from JSON.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the cluster search shards response
+     * @throws IOException if parsing fails
+     */
     protected ClusterSearchShardsResponse fromXContent(final XContentParser parser) throws IOException {
         // ClusterSearchShardsResponse contains complex internal structures
         // (ShardRouting, AliasFilter) that are difficult to construct from JSON.
@@ -60,6 +85,12 @@ public class HttpClusterSearchShardsAction extends HttpAction {
         return new ClusterSearchShardsResponse(new ClusterSearchShardsGroup[0], new DiscoveryNode[0], Collections.emptyMap());
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -73,6 +104,12 @@ public class HttpClusterSearchShardsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the cluster search shards API.
+     *
+     * @param request the cluster search shards request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ClusterSearchShardsRequest request) {
         // RestClusterSearchShardsAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterStateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterStateAction.java
@@ -30,15 +30,31 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the cluster state API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpClusterStateAction extends HttpAction {
 
+    /** The cluster state action. */
     protected final ClusterStateAction action;
 
+    /**
+     * Creates a new HTTP cluster state action.
+     *
+     * @param client the HTTP client
+     * @param action the cluster state action
+     */
     public HttpClusterStateAction(final HttpClient client, final ClusterStateAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster state request asynchronously.
+     *
+     * @param request the cluster state request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterStateRequest request, final ActionListener<ClusterStateResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -50,6 +66,15 @@ public class HttpClusterStateAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a cluster state response from the given parser. Only the cluster name and the
+     * wait-for-timed-out flag are extracted; the cluster state itself is returned empty because
+     * it cannot be fully reconstructed from JSON.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the cluster state response
+     * @throws IOException if parsing fails
+     */
     protected ClusterStateResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         ClusterName clusterName = ClusterName.DEFAULT;
@@ -83,6 +108,12 @@ public class HttpClusterStateAction extends HttpAction {
         return new ClusterStateResponse(clusterName, clusterState, waitForTimedOut);
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -96,6 +127,12 @@ public class HttpClusterStateAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the cluster state API.
+     *
+     * @param request the cluster state request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ClusterStateRequest request) {
         // RestClusterStateAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterStatsAction.java
@@ -33,15 +33,31 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the cluster stats API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpClusterStatsAction extends HttpAction {
 
+    /** The cluster stats action. */
     protected ClusterStatsAction action;
 
+    /**
+     * Creates a new HTTP cluster stats action.
+     *
+     * @param client the HTTP client
+     * @param action the cluster stats action
+     */
     public HttpClusterStatsAction(final HttpClient client, final ClusterStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster stats request asynchronously.
+     *
+     * @param request the cluster stats request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterStatsRequest request, final ActionListener<ClusterStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -53,6 +69,15 @@ public class HttpClusterStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a cluster stats response from the given parser. Basic fields such as the timestamp,
+     * cluster UUID, cluster name, and status are extracted; the nodes and indices sections are
+     * skipped because they cannot be fully reconstructed from JSON.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the cluster stats response
+     * @throws IOException if parsing fails
+     */
     protected ClusterStatsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         String clusterUUID = null;
@@ -106,11 +131,23 @@ public class HttpClusterStatsAction extends HttpAction {
         return response;
     }
 
+    /**
+     * Skips the {@code _nodes} section of the response.
+     *
+     * @param parser the parser positioned inside the {@code _nodes} object
+     * @throws IOException if parsing fails
+     */
     protected void parseNodeResults(final XContentParser parser) throws IOException {
         // Skip _nodes section
         consumeObject(parser);
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -124,6 +161,12 @@ public class HttpClusterStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the cluster stats API.
+     *
+     * @param request the cluster stats request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ClusterStatsRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_cluster/stats");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterUpdateSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterUpdateSettingsAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the cluster update settings API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpClusterUpdateSettingsAction extends HttpAction {
 
+    /** The cluster update settings action. */
     protected final ClusterUpdateSettingsAction action;
 
+    /**
+     * Creates a new HTTP cluster update settings action.
+     *
+     * @param client the HTTP client
+     * @param action the cluster update settings action
+     */
     public HttpClusterUpdateSettingsAction(final HttpClient client, final ClusterUpdateSettingsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the cluster update settings request asynchronously.
+     *
+     * @param request the cluster update settings request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ClusterUpdateSettingsRequest request, final ActionListener<ClusterUpdateSettingsResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -57,6 +73,12 @@ public class HttpClusterUpdateSettingsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the cluster update settings API.
+     *
+     * @param request the cluster update settings request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ClusterUpdateSettingsRequest request) {
         // RestClusterUpdateSettingsAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/_cluster/settings");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCreateIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCreateIndexAction.java
@@ -37,19 +37,40 @@ import org.opensearch.core.xcontent.ToXContent.Params;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the create index API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpCreateIndexAction extends HttpAction {
 
+    /** The field name for index mappings. */
     protected static final ParseField MAPPINGS = new ParseField("mappings");
+
+    /** The field name for index settings. */
     protected static final ParseField SETTINGS = new ParseField("settings");
+
+    /** The field name for index aliases. */
     protected static final ParseField ALIASES = new ParseField("aliases");
 
+    /** The create index action. */
     protected final CreateIndexAction action;
 
+    /**
+     * Creates a new HTTP create index action.
+     *
+     * @param client the HTTP client
+     * @param action the create index action
+     */
     public HttpCreateIndexAction(final HttpClient client, final CreateIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the create index request asynchronously.
+     *
+     * @param request the create index request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CreateIndexRequest request, final ActionListener<CreateIndexResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = toXContent(request, JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -68,6 +89,15 @@ public class HttpCreateIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Serializes the create index request to the given builder as a JSON object.
+     *
+     * @param request the create index request
+     * @param builder the content builder to write to
+     * @param params the serialization parameters
+     * @return the builder
+     * @throws IOException if writing fails
+     */
     protected XContentBuilder toXContent(final CreateIndexRequest request, final XContentBuilder builder, final Params params)
             throws IOException {
         builder.startObject();
@@ -76,6 +106,15 @@ public class HttpCreateIndexAction extends HttpAction {
         return builder;
     }
 
+    /**
+     * Writes the settings, mappings, and aliases of the create index request to the given builder.
+     *
+     * @param request the create index request
+     * @param builder the content builder to write to
+     * @param params the serialization parameters
+     * @return the builder
+     * @throws IOException if writing fails
+     */
     protected XContentBuilder innerToXContent(final CreateIndexRequest request, final XContentBuilder builder, final Params params)
             throws IOException {
         builder.startObject(SETTINGS.getPreferredName());
@@ -109,6 +148,12 @@ public class HttpCreateIndexAction extends HttpAction {
         return builder;
     }
 
+    /**
+     * Builds the curl request for the create index API.
+     *
+     * @param request the create index request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final CreateIndexRequest request) {
         // RestCreateIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/", request.index());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCreateSnapshotAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCreateSnapshotAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the create snapshot API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpCreateSnapshotAction extends HttpAction {
 
+    /** The create snapshot action. */
     protected final CreateSnapshotAction action;
 
+    /**
+     * Creates a new HTTP create snapshot action.
+     *
+     * @param client the HTTP client
+     * @param action the create snapshot action
+     */
     public HttpCreateSnapshotAction(final HttpClient client, final CreateSnapshotAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the create snapshot request asynchronously.
+     *
+     * @param request the create snapshot request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CreateSnapshotRequest request, final ActionListener<CreateSnapshotResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -58,6 +74,12 @@ public class HttpCreateSnapshotAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the create snapshot API.
+     *
+     * @param request the create snapshot request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final CreateSnapshotRequest request) {
         // RestCreateSnapshotAction
         final StringBuilder pathBuf = new StringBuilder(100).append("/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCreateViewAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCreateViewAction.java
@@ -28,15 +28,31 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the create view API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpCreateViewAction extends HttpAction {
 
+    /** The create view action. */
     protected final CreateViewAction action;
 
+    /**
+     * Creates a new HTTP create view action.
+     *
+     * @param client the HTTP client
+     * @param action the create view action
+     */
     public HttpCreateViewAction(final HttpClient client, final CreateViewAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the create view request asynchronously.
+     *
+     * @param request the create view request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CreateViewAction.Request request, final ActionListener<GetViewAction.Response> listener) {
         final String source = buildRequestBody(request);
         getCurlRequest(request).body(source).execute(response -> {
@@ -49,6 +65,12 @@ public class HttpCreateViewAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the JSON request body for the create view request.
+     *
+     * @param request the create view request
+     * @return the JSON request body
+     */
     protected String buildRequestBody(final CreateViewAction.Request request) {
         try (final XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
@@ -69,6 +91,12 @@ public class HttpCreateViewAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the create view API.
+     *
+     * @param request the create view request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final CreateViewAction.Request request) {
         // RestViewAction
         return client.getCurlRequest(POST, "/views");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDataStreamsStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDataStreamsStatsAction.java
@@ -29,15 +29,31 @@ import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the data streams stats API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDataStreamsStatsAction extends HttpAction {
 
+    /** The data streams stats action. */
     protected DataStreamsStatsAction action;
 
+    /**
+     * Creates a new HTTP data streams stats action.
+     *
+     * @param client the HTTP client
+     * @param action the data streams stats action
+     */
     public HttpDataStreamsStatsAction(final HttpClient client, final DataStreamsStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the data streams stats request asynchronously.
+     *
+     * @param request the data streams stats request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final DataStreamsStatsAction.Request request, final ActionListener<DataStreamsStatsAction.Response> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -49,6 +65,13 @@ public class HttpDataStreamsStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a data streams stats response from the given parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the data streams stats response
+     * @throws IOException if parsing fails
+     */
     protected DataStreamsStatsAction.Response fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -113,6 +136,13 @@ public class HttpDataStreamsStatsAction extends HttpAction {
                 backingIndices, new ByteSizeValue(totalStoreSizeBytes), dataStreams.toArray(new DataStreamsStatsAction.DataStreamStats[0]));
     }
 
+    /**
+     * Parses the stats of a single data stream from the given parser.
+     *
+     * @param parser the parser positioned at a data stream object
+     * @return the data stream stats
+     * @throws IOException if parsing fails
+     */
     protected DataStreamsStatsAction.DataStreamStats parseDataStreamStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         String dataStream = null;
@@ -144,6 +174,12 @@ public class HttpDataStreamsStatsAction extends HttpAction {
         return new DataStreamsStatsAction.DataStreamStats(dataStream, backingIndices, new ByteSizeValue(storeSizeBytes), maximumTimestamp);
     }
 
+    /**
+     * Consumes the current object from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the object to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -157,6 +193,12 @@ public class HttpDataStreamsStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes the current array from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeArray(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -170,6 +212,12 @@ public class HttpDataStreamsStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the data streams stats API.
+     *
+     * @param request the data streams stats request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final DataStreamsStatsAction.Request request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_data_stream");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteAction.java
@@ -33,15 +33,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
 
+/**
+ * Handles the delete document API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteAction extends HttpAction {
 
+    /** The delete action definition. */
     protected final DeleteAction action;
 
+    /**
+     * Creates a new HttpDeleteAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete action definition
+     */
     public HttpDeleteAction(final HttpClient client, final DeleteAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete request
+     * @param listener the listener to notify with the delete response or a failure
+     */
     public void execute(final DeleteRequest request, final ActionListener<DeleteResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -54,6 +70,13 @@ public class HttpDeleteAction extends HttpAction {
     }
 
     // DeleteResponse.fromXContent(parser)
+    /**
+     * Parses a delete response from the given XContent parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the parsed delete response
+     * @throws IOException if parsing the response fails
+     */
     protected DeleteResponse fromXContent(final XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
@@ -64,6 +87,12 @@ public class HttpDeleteAction extends HttpAction {
         return context.build();
     }
 
+    /**
+     * Builds the HTTP request for the delete request.
+     *
+     * @param request the delete request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteRequest request) {
         // RestDeleteAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/_doc/" + UrlUtils.encode(request.id()), request.index());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete index API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteIndexAction extends HttpAction {
 
+    /** The delete index action definition. */
     protected final DeleteIndexAction action;
 
+    /**
+     * Creates a new HttpDeleteIndexAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete index action definition
+     */
     public HttpDeleteIndexAction(final HttpClient client, final DeleteIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete index request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete index request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteIndexRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpDeleteIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete index request.
+     *
+     * @param request the delete index request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteIndexRequest request) {
         // RestDeleteIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexTemplateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexTemplateAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete index template API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteIndexTemplateAction extends HttpAction {
 
+    /** The delete index template action definition. */
     protected final DeleteIndexTemplateAction action;
 
+    /**
+     * Creates a new HttpDeleteIndexTemplateAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete index template action definition
+     */
     public HttpDeleteIndexTemplateAction(final HttpClient client, final DeleteIndexTemplateAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete index template request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete index template request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteIndexTemplateRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpDeleteIndexTemplateAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete index template request.
+     *
+     * @param request the delete index template request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteIndexTemplateRequest request) {
         // RestDeleteIndexTemplatesAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/_template/" + UrlUtils.encode(request.name()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeletePipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeletePipelineAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete ingest pipeline API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeletePipelineAction extends HttpAction {
 
+    /** The delete pipeline action definition. */
     protected final DeletePipelineAction action;
 
+    /**
+     * Creates a new HttpDeletePipelineAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete pipeline action definition
+     */
     public HttpDeletePipelineAction(final HttpClient client, final DeletePipelineAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete pipeline request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete pipeline request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeletePipelineRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpDeletePipelineAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete pipeline request.
+     *
+     * @param request the delete pipeline request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeletePipelineRequest request) {
         // RestDeletePipelineAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/_ingest/pipeline/" + UrlUtils.encode(request.getId()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteRepositoryAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete snapshot repository API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteRepositoryAction extends HttpAction {
 
+    /** The delete repository action definition. */
     protected final DeleteRepositoryAction action;
 
+    /**
+     * Creates a new HttpDeleteRepositoryAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete repository action definition
+     */
     public HttpDeleteRepositoryAction(final HttpClient client, final DeleteRepositoryAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete repository request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete repository request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteRepositoryRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpDeleteRepositoryAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete repository request.
+     *
+     * @param request the delete repository request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteRepositoryRequest request) {
         // RestVerifyRepositoryAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/_snapshot/" + UrlUtils.encode(request.name()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteSnapshotAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteSnapshotAction.java
@@ -27,15 +27,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete snapshot API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteSnapshotAction extends HttpAction {
 
+    /** The delete snapshot action definition. */
     protected final DeleteSnapshotAction action;
 
+    /**
+     * Creates a new HttpDeleteSnapshotAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete snapshot action definition
+     */
     public HttpDeleteSnapshotAction(final HttpClient client, final DeleteSnapshotAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete snapshot request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete snapshot request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteSnapshotRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -47,6 +63,12 @@ public class HttpDeleteSnapshotAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete snapshot request.
+     *
+     * @param request the delete snapshot request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteSnapshotRequest request) {
         // RestDeleteSnapshotAction
         final StringBuilder pathBuf = new StringBuilder(100).append("/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteStoredScriptAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteStoredScriptAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete stored script API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpDeleteStoredScriptAction extends HttpAction {
 
+    /** The delete stored script action definition. */
     protected final DeleteStoredScriptAction action;
 
+    /**
+     * Creates a new HttpDeleteStoredScriptAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete stored script action definition
+     */
     public HttpDeleteStoredScriptAction(final HttpClient client, final DeleteStoredScriptAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete stored script request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete stored script request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteStoredScriptRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpDeleteStoredScriptAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete stored script request.
+     *
+     * @param request the delete stored script request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteStoredScriptRequest request) {
         // RestDeleteStoredScriptAction
         final CurlRequest curlRequest = client.getCurlRequest(DELETE, "/_scripts/" + UrlUtils.encode(request.id()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteViewAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteViewAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the delete view API over HTTP for OpenSearch.
+ */
 public class HttpDeleteViewAction extends HttpAction {
 
+    /** The delete view action definition. */
     protected final DeleteViewAction action;
 
+    /**
+     * Creates a new HttpDeleteViewAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete view action definition
+     */
     public HttpDeleteViewAction(final HttpClient client, final DeleteViewAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the delete view request asynchronously and notifies the listener with the result.
+     *
+     * @param request the delete view request
+     * @param listener the listener to notify with the acknowledged response or a failure
+     */
     public void execute(final DeleteViewAction.Request request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpDeleteViewAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the delete view request.
+     *
+     * @param request the delete view request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final DeleteViewAction.Request request) {
         // RestViewAction
         return client.getCurlRequest(DELETE, "/views/" + UrlUtils.encode(request.getName()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpExplainAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpExplainAction.java
@@ -36,15 +36,31 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.get.GetResult;
 
+/**
+ * Handles the explain API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpExplainAction extends HttpAction {
 
+    /** The explain action definition. */
     protected final ExplainAction action;
 
+    /**
+     * Creates a new HttpExplainAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the explain action definition
+     */
     public HttpExplainAction(final HttpClient client, final ExplainAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the explain request asynchronously and notifies the listener with the result.
+     *
+     * @param request the explain request
+     * @param listener the listener to notify with the explain response or a failure
+     */
     public void execute(final ExplainRequest request, final ActionListener<ExplainResponse> listener) {
         String source = null;
         try (final XContentBuilder builder =
@@ -65,6 +81,14 @@ public class HttpExplainAction extends HttpAction {
     }
 
     // ExplainResponse.fromXContent(parser, true)
+    /**
+     * Parses an explain response from the given XContent parser, using an engine-specific
+     * parser for Elasticsearch 8 and OpenSearch 2 backends.
+     *
+     * @param parser the parser positioned at the response body
+     * @param exists whether the document exists
+     * @return the parsed explain response
+     */
     protected ExplainResponse fromXContent(final XContentParser parser, final boolean exists) {
         final EngineType engineType = client.getEngineInfo().getType();
         if (engineType == EngineType.ELASTICSEARCH8 || engineType == EngineType.OPENSEARCH2) {
@@ -73,6 +97,11 @@ public class HttpExplainAction extends HttpAction {
         return ExplainResponse.fromXContent(parser, exists);
     }
 
+    /**
+     * Creates a response parser for explain responses that do not contain the _type field.
+     *
+     * @return the explain response parser
+     */
     protected ConstructingObjectParser<ExplainResponse, Boolean> getResponseParser() {
         // remove _type
         final ConstructingObjectParser<ExplainResponse, Boolean> parser = new ConstructingObjectParser<>("explain", true,
@@ -95,6 +124,12 @@ public class HttpExplainAction extends HttpAction {
         return parser;
     }
 
+    /**
+     * Builds the HTTP request for the explain request.
+     *
+     * @param request the explain request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final ExplainRequest request) {
         // RestExplainAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_explain/" + UrlUtils.encode(request.id()), request.index());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the field capabilities API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpFieldCapabilitiesAction extends HttpAction {
 
+    /** The field capabilities action definition. */
     protected final FieldCapabilitiesAction action;
 
+    /**
+     * Creates a new HttpFieldCapabilitiesAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the field capabilities action definition
+     */
     public HttpFieldCapabilitiesAction(final HttpClient client, final FieldCapabilitiesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the field capabilities request asynchronously and notifies the listener with the result.
+     *
+     * @param request the field capabilities request
+     * @param listener the listener to notify with the field capabilities response or a failure
+     */
     public void execute(final FieldCapabilitiesRequest request, final ActionListener<FieldCapabilitiesResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpFieldCapabilitiesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the HTTP request for the field capabilities request.
+     *
+     * @param request the field capabilities request
+     * @return the configured curl request
+     */
     protected CurlRequest getCurlRequest(final FieldCapabilitiesRequest request) {
         // RestFieldCapabilitiesAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_field_caps", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpFlushAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpFlushAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.admin.indices.flush.FlushResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Flush API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpFlushAction extends HttpAction {
 
+    /** The flush action definition. */
     protected final FlushAction action;
 
+    /**
+     * Creates a new HTTP flush action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the flush action definition
+     */
     public HttpFlushAction(final HttpClient client, final FlushAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the flush request asynchronously.
+     *
+     * @param request the flush request
+     * @param listener the listener notified with the flush response or a failure
+     */
     public void execute(final FlushRequest request, final ActionListener<FlushResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpFlushAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the flush API.
+     *
+     * @param request the flush request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final FlushRequest request) {
         // RestFlushAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_flush", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Force Merge API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpForceMergeAction extends HttpAction {
 
+    /** The force merge action definition. */
     protected final ForceMergeAction action;
 
+    /**
+     * Creates a new HTTP force merge action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the force merge action definition
+     */
     public HttpForceMergeAction(final HttpClient client, final ForceMergeAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the force merge request asynchronously.
+     *
+     * @param request the force merge request
+     * @param listener the listener notified with the force merge response or a failure
+     */
     public void execute(final ForceMergeRequest request, final ActionListener<ForceMergeResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpForceMergeAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the force merge API.
+     *
+     * @param request the force merge request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final ForceMergeRequest request) {
         // RestForceMergeAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_forcemerge", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetAction.java
@@ -28,15 +28,31 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.VersionType;
 
+/**
+ * Handles the Get Document API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetAction extends HttpAction {
 
+    /** The get action definition. */
     protected final GetAction action;
 
+    /**
+     * Creates a new HTTP get action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get action definition
+     */
     public HttpGetAction(final HttpClient client, final GetAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get request asynchronously.
+     *
+     * @param request the get request
+     * @param listener the listener notified with the get response or a failure
+     */
     public void execute(final GetRequest request, final ActionListener<GetResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetAliasesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetAliasesAction.java
@@ -34,15 +34,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
 
+/**
+ * Handles the Get Aliases API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetAliasesAction extends HttpAction {
 
+    /** The get aliases action definition. */
     protected final GetAliasesAction action;
 
+    /**
+     * Creates a new HTTP get aliases action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get aliases action definition
+     */
     public HttpGetAliasesAction(final HttpClient client, final GetAliasesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get aliases request asynchronously.
+     *
+     * @param request the get aliases request
+     * @param listener the listener notified with the get aliases response or a failure
+     */
     public void execute(final GetAliasesRequest request, final ActionListener<GetAliasesResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -54,6 +70,12 @@ public class HttpGetAliasesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get aliases API.
+     *
+     * @param request the get aliases request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetAliasesRequest request) {
         // RestGetAliasesAction
         final CurlRequest curlRequest =
@@ -62,6 +84,13 @@ public class HttpGetAliasesAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Parses the HTTP response body into a {@link GetAliasesResponse}.
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed get aliases response
+     * @throws IOException if parsing fails
+     */
     protected GetAliasesResponse getGetAliasesResponse(final XContentParser parser) throws IOException {
         final Map<String, List<AliasMetadata>> aliases = new HashMap<>();
 
@@ -96,6 +125,13 @@ public class HttpGetAliasesAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses a list of alias metadata entries from the parser.
+     *
+     * @param parser the content parser positioned at an aliases object
+     * @return the list of parsed alias metadata
+     * @throws IOException if parsing fails
+     */
     public static List<AliasMetadata> getAliases(final XContentParser parser) throws IOException {
         final List<AliasMetadata> aliases = new ArrayList<>();
         XContentParser.Token token = parser.nextToken();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetFieldMappingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetFieldMappingsAction.java
@@ -37,15 +37,31 @@ import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.ObjectParser;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Get Field Mappings API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetFieldMappingsAction extends HttpAction {
 
+    /** The get field mappings action definition. */
     protected final GetFieldMappingsAction action;
 
+    /**
+     * Creates a new HTTP get field mappings action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get field mappings action definition
+     */
     public HttpGetFieldMappingsAction(final HttpClient client, final GetFieldMappingsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get field mappings request asynchronously.
+     *
+     * @param request the get field mappings request
+     * @param listener the listener notified with the get field mappings response or a failure
+     */
     public void execute(final GetFieldMappingsRequest request, final ActionListener<GetFieldMappingsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -57,6 +73,12 @@ public class HttpGetFieldMappingsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get field mappings API.
+     *
+     * @param request the get field mappings request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetFieldMappingsRequest request) {
         // RestGetFieldMappingsAction
         final StringBuilder pathSuffix = new StringBuilder(100).append("/_mapping/field/");
@@ -71,6 +93,13 @@ public class HttpGetFieldMappingsAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Parses the HTTP response body into a {@link GetFieldMappingsResponse}.
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed get field mappings response
+     * @throws IOException if parsing fails
+     */
     protected GetFieldMappingsResponse fromXContent(final XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         final Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>>> mappings = new HashMap<>();
@@ -88,6 +117,14 @@ public class HttpGetFieldMappingsAction extends HttpAction {
         return newGetFieldMappingsResponse(mappings);
     }
 
+    /**
+     * Parses the type-level mappings of an index entry.
+     *
+     * @param parser the content parser positioned at an index entry
+     * @param index the index name being parsed
+     * @return a map of type name to field mapping metadata
+     * @throws IOException if parsing fails
+     */
     protected Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>> parseTypeMappings(final XContentParser parser,
             final String index) throws IOException {
         final ObjectParser<Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>>, String> objectParser =
@@ -115,6 +152,13 @@ public class HttpGetFieldMappingsAction extends HttpAction {
         return objectParser.parse(parser, index);
     }
 
+    /**
+     * Parses a single field mapping metadata entry.
+     *
+     * @param parser the content parser positioned at a field mapping object
+     * @return the parsed field mapping metadata
+     * @throws IOException if parsing fails
+     */
     protected GetFieldMappingsResponse.FieldMappingMetadata getFieldMappingMetadata(final XContentParser parser) throws IOException {
         final ConstructingObjectParser<GetFieldMappingsResponse.FieldMappingMetadata, String> objectParser =
                 new ConstructingObjectParser<>("field_mapping_meta_data", true,
@@ -129,6 +173,13 @@ public class HttpGetFieldMappingsAction extends HttpAction {
         return objectParser.parse(parser, null);
     }
 
+    /**
+     * Creates a {@link GetFieldMappingsResponse} from the parsed mappings via reflection,
+     * because the constructor is not publicly accessible.
+     *
+     * @param mappings the parsed mappings keyed by index, type, and field name
+     * @return a new get field mappings response
+     */
     protected GetFieldMappingsResponse newGetFieldMappingsResponse(
             final Map<String, Map<String, Map<String, GetFieldMappingsResponse.FieldMappingMetadata>>> mappings) {
         final Class<GetFieldMappingsResponse> clazz = GetFieldMappingsResponse.class;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexAction.java
@@ -38,15 +38,31 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Get Index API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetIndexAction extends HttpAction {
 
+    /** The get index action definition. */
     protected final GetIndexAction action;
 
+    /**
+     * Creates a new HTTP get index action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get index action definition
+     */
     public HttpGetIndexAction(final HttpClient client, final GetIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get index request asynchronously.
+     *
+     * @param request the get index request
+     * @param listener the listener notified with the get index response or a failure
+     */
     public void execute(final GetIndexRequest request, final ActionListener<GetIndexResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -58,6 +74,12 @@ public class HttpGetIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get index API.
+     *
+     * @param request the get index request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetIndexRequest request) {
         // RestGetIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/", request.indices());
@@ -65,6 +87,13 @@ public class HttpGetIndexAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Parses the HTTP response body into a {@link GetIndexResponse}.
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed get index response
+     * @throws IOException if parsing fails
+     */
     protected static GetIndexResponse fromXContent(final XContentParser parser) throws IOException {
         Map<String, MappingMetadata> mappings = new HashMap<>();
         final Map<String, List<AliasMetadata>> aliases = new HashMap<>();
@@ -109,6 +138,13 @@ public class HttpGetIndexAction extends HttpAction {
         return new GetIndexResponse(indices.toArray(new String[0]), mappings, aliases, settings, defaultSettings, dataStreams, contexts);
     }
 
+    /**
+     * Parses a single index entry containing aliases, mappings, settings, and related metadata.
+     *
+     * @param parser the content parser positioned at an index entry object
+     * @return the parsed index entry
+     * @throws IOException if parsing fails
+     */
     protected static IndexEntry parseIndexEntry(final XContentParser parser) throws IOException {
         List<AliasMetadata> indexAliases = null;
         Map<String, MappingMetadata> indexMappings = null;
@@ -152,6 +188,13 @@ public class HttpGetIndexAction extends HttpAction {
         return new IndexEntry(indexAliases, indexMappings, indexSettings, indexDefaultSettings, dataStream, context);
     }
 
+    /**
+     * Parses the aliases section of an index entry.
+     *
+     * @param parser the content parser positioned at the aliases object
+     * @return the list of parsed alias metadata
+     * @throws IOException if parsing fails
+     */
     protected static List<AliasMetadata> parseAliases(final XContentParser parser) throws IOException {
         final List<AliasMetadata> indexAliases = new ArrayList<>();
         // We start at START_OBJECT since parseIndexEntry ensures that
@@ -162,6 +205,13 @@ public class HttpGetIndexAction extends HttpAction {
         return indexAliases;
     }
 
+    /**
+     * Parses the mappings section of an index entry.
+     *
+     * @param parser the content parser positioned at the mappings object
+     * @return a map of mapping type name to mapping metadata
+     * @throws IOException if parsing fails
+     */
     protected static Map<String, MappingMetadata> parseMappings(final XContentParser parser) throws IOException {
         final Map<String, MappingMetadata> indexMappings = new HashMap<>();
         // We start at START_OBJECT since parseIndexEntry ensures that
@@ -179,6 +229,9 @@ public class HttpGetIndexAction extends HttpAction {
     }
 
     // This is just an internal container to make stuff easier for returning
+    /**
+     * Internal container holding the parsed metadata of a single index entry.
+     */
     protected static class IndexEntry {
         List<AliasMetadata> indexAliases = new ArrayList<>();
         Map<String, MappingMetadata> indexMappings = new HashMap<>();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexTemplatesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetIndexTemplatesAction.java
@@ -29,15 +29,31 @@ import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Get Index Templates API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetIndexTemplatesAction extends HttpAction {
 
+    /** The get index templates action definition. */
     protected final GetIndexTemplatesAction action;
 
+    /**
+     * Creates a new HTTP get index templates action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get index templates action definition
+     */
     public HttpGetIndexTemplatesAction(final HttpClient client, final GetIndexTemplatesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get index templates request asynchronously.
+     *
+     * @param request the get index templates request
+     * @param listener the listener notified with the get index templates response or a failure
+     */
     public void execute(final GetIndexTemplatesRequest request, final ActionListener<GetIndexTemplatesResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -49,6 +65,12 @@ public class HttpGetIndexTemplatesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get index templates API.
+     *
+     * @param request the get index templates request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetIndexTemplatesRequest request) {
         // RestGetIndexTemplateAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_template/" + UrlUtils.joinAndEncode(",", request.names()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetIngestionStateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetIngestionStateAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Get Ingestion State API over HTTP for OpenSearch.
+ */
 public class HttpGetIngestionStateAction extends HttpAction {
 
+    /** The get ingestion state action definition. */
     protected final GetIngestionStateAction action;
 
+    /**
+     * Creates a new HTTP get ingestion state action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get ingestion state action definition
+     */
     public HttpGetIngestionStateAction(final HttpClient client, final GetIngestionStateAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get ingestion state request asynchronously.
+     *
+     * @param request the get ingestion state request
+     * @param listener the listener notified with the get ingestion state response or a failure
+     */
     public void execute(final GetIngestionStateRequest request, final ActionListener<GetIngestionStateResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -51,6 +67,13 @@ public class HttpGetIngestionStateAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the HTTP response body into a {@link GetIngestionStateResponse}.
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed get ingestion state response
+     * @throws IOException if parsing fails
+     */
     protected GetIngestionStateResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -101,6 +124,13 @@ public class HttpGetIngestionStateAction extends HttpAction {
                 nextPageToken, shardFailures);
     }
 
+    /**
+     * Parses the ingestion_state section and adds the shard states to the given list.
+     *
+     * @param parser the content parser positioned at the ingestion_state object
+     * @param shardStates the list to which parsed shard ingestion states are added
+     * @throws IOException if parsing fails
+     */
     protected void parseIngestionState(final XContentParser parser, final List<ShardIngestionState> shardStates) throws IOException {
         // ingestion_state: { "index_name": [ {shard fields...}, ... ], ... }
         XContentParser.Token token;
@@ -119,6 +149,14 @@ public class HttpGetIngestionStateAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses a single shard ingestion state entry.
+     *
+     * @param parser the content parser positioned at a shard state object
+     * @param indexName the name of the index the shard belongs to
+     * @return the parsed shard ingestion state
+     * @throws IOException if parsing fails
+     */
     protected ShardIngestionState parseShardIngestionState(final XContentParser parser, final String indexName) throws IOException {
         int shardId = -1;
         String pollerState = null;
@@ -165,6 +203,12 @@ public class HttpGetIngestionStateAction extends HttpAction {
                 isPrimary, nodeName);
     }
 
+    /**
+     * Consumes and discards the current object or array, including all nested structures.
+     *
+     * @param parser the content parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -178,6 +222,12 @@ public class HttpGetIngestionStateAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the get ingestion state API.
+     *
+     * @param request the get ingestion state request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetIngestionStateRequest request) {
         // RestGetIngestionStateAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/ingestion/_state", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetMappingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetMappingsAction.java
@@ -31,17 +31,33 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 
+/**
+ * Handles the Get Mappings API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetMappingsAction extends HttpAction {
 
+    /** The get mappings action definition. */
     protected final GetMappingsAction action;
 
     private static final ParseField MAPPINGS = new ParseField("mappings");
 
+    /**
+     * Creates a new HTTP get mappings action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get mappings action definition
+     */
     public HttpGetMappingsAction(final HttpClient client, final GetMappingsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get mappings request asynchronously.
+     *
+     * @param request the get mappings request
+     * @param listener the listener notified with the get mappings response or a failure
+     */
     public void execute(final GetMappingsRequest request, final ActionListener<GetMappingsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             if (response.getHttpStatusCode() == 404) {
@@ -56,6 +72,12 @@ public class HttpGetMappingsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get mappings API.
+     *
+     * @param request the get mappings request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetMappingsRequest request) {
         // RestGetMappingAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_mapping", request.indices());
@@ -67,6 +89,14 @@ public class HttpGetMappingsAction extends HttpAction {
 
     // GetMappingsResponse does not provide fromXContent.
     // This custom implementation skips dynamic_templates for compatibility with older versions.
+    /**
+     * Parses the HTTP response body into a {@link GetMappingsResponse}.
+     * Skips dynamic_templates entries for compatibility with older versions.
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed get mappings response
+     * @throws IOException if parsing fails
+     */
     public static GetMappingsResponse fromXContent(final XContentParser parser) throws IOException {
         if (parser.currentToken() == null) {
             parser.nextToken();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetPipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetPipelineAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.ingest.GetPipelineResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Get Pipeline API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpGetPipelineAction extends HttpAction {
 
+    /** The get pipeline action definition. */
     protected final GetPipelineAction action;
 
+    /**
+     * Creates a new HTTP get pipeline action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get pipeline action definition
+     */
     public HttpGetPipelineAction(final HttpClient client, final GetPipelineAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get pipeline request asynchronously.
+     *
+     * @param request the get pipeline request
+     * @param listener the listener notified with the get pipeline response or a failure
+     */
     public void execute(final GetPipelineRequest request, final ActionListener<GetPipelineResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpGetPipelineAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get pipeline API.
+     *
+     * @param request the get pipeline request
+     * @return the curl request to send
+     */
     protected CurlRequest getCurlRequest(final GetPipelineRequest request) {
         // RestGetPipelineAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_ingest/pipeline/" + UrlUtils.joinAndEncode(",", request.getIds()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetRepositoriesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetRepositoriesAction.java
@@ -23,15 +23,32 @@ import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRespo
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the get repositories API over HTTP for OpenSearch/Elasticsearch,
+ * retrieving information about registered snapshot repositories.
+ */
 public class HttpGetRepositoriesAction extends HttpAction {
 
+    /** The get repositories action. */
     protected final GetRepositoriesAction action;
 
+    /**
+     * Creates a new HttpGetRepositoriesAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get repositories action
+     */
     public HttpGetRepositoriesAction(final HttpClient client, final GetRepositoriesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get repositories request and notifies the listener with the response.
+     *
+     * @param request the get repositories request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetRepositoriesRequest request, final ActionListener<GetRepositoriesResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +60,12 @@ public class HttpGetRepositoriesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get repositories API.
+     *
+     * @param request the get repositories request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetRepositoriesRequest request) {
         // RestGetRepositoriesAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetSettingsAction.java
@@ -24,15 +24,32 @@ import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the get settings API over HTTP for OpenSearch/Elasticsearch,
+ * retrieving settings of one or more indices.
+ */
 public class HttpGetSettingsAction extends HttpAction {
 
+    /** The get settings action. */
     protected final GetSettingsAction action;
 
+    /**
+     * Creates a new HttpGetSettingsAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get settings action
+     */
     public HttpGetSettingsAction(final HttpClient client, final GetSettingsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get settings request and notifies the listener with the response.
+     *
+     * @param request the get settings request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetSettingsRequest request, final ActionListener<GetSettingsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +61,12 @@ public class HttpGetSettingsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get settings API.
+     *
+     * @param request the get settings request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetSettingsRequest request) {
         // RestGetSettingsAction
         final CurlRequest curlRequest =

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetSnapshotsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetSnapshotsAction.java
@@ -24,15 +24,32 @@ import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the get snapshots API over HTTP for OpenSearch/Elasticsearch,
+ * retrieving information about snapshots in a repository.
+ */
 public class HttpGetSnapshotsAction extends HttpAction {
 
+    /** The get snapshots action. */
     protected final GetSnapshotsAction action;
 
+    /**
+     * Creates a new HttpGetSnapshotsAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get snapshots action
+     */
     public HttpGetSnapshotsAction(final HttpClient client, final GetSnapshotsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get snapshots request and notifies the listener with the response.
+     *
+     * @param request the get snapshots request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetSnapshotsRequest request, final ActionListener<GetSnapshotsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +61,12 @@ public class HttpGetSnapshotsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get snapshots API.
+     *
+     * @param request the get snapshots request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetSnapshotsRequest request) {
         // RestGetSnapshotsAction
         final StringBuilder pathBuf = new StringBuilder(100).append("/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetStoredScriptAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetStoredScriptAction.java
@@ -24,15 +24,32 @@ import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptResponse
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the get stored script API over HTTP for OpenSearch/Elasticsearch,
+ * retrieving a stored script by its id.
+ */
 public class HttpGetStoredScriptAction extends HttpAction {
 
+    /** The get stored script action. */
     protected final GetStoredScriptAction action;
 
+    /**
+     * Creates a new HttpGetStoredScriptAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get stored script action
+     */
     public HttpGetStoredScriptAction(final HttpClient client, final GetStoredScriptAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get stored script request and notifies the listener with the response.
+     *
+     * @param request the get stored script request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetStoredScriptRequest request, final ActionListener<GetStoredScriptResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +61,12 @@ public class HttpGetStoredScriptAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get stored script API.
+     *
+     * @param request the get stored script request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetStoredScriptRequest request) {
         // RestGetStoredScriptAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_scripts/" + UrlUtils.encode(request.id()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetTaskAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetTaskAction.java
@@ -26,15 +26,32 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.tasks.TaskResult;
 
+/**
+ * Handles the get task API over HTTP for OpenSearch/Elasticsearch,
+ * retrieving information about a task currently running in the cluster.
+ */
 public class HttpGetTaskAction extends HttpAction {
 
+    /** The get task action. */
     protected final GetTaskAction action;
 
+    /**
+     * Creates a new HttpGetTaskAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get task action
+     */
     public HttpGetTaskAction(final HttpClient client, final GetTaskAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get task request and notifies the listener with the response.
+     *
+     * @param request the get task request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetTaskRequest request, final ActionListener<GetTaskResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -46,12 +63,25 @@ public class HttpGetTaskAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a get task response from the given parser.
+     *
+     * @param parser the parser for the response body
+     * @return the parsed get task response
+     * @throws IOException if the response cannot be parsed
+     */
     protected GetTaskResponse fromXContent(final XContentParser parser) throws IOException {
         parser.nextToken();
         final TaskResult taskResult = TaskResult.PARSER.apply(parser, null);
         return new GetTaskResponse(taskResult);
     }
 
+    /**
+     * Builds the curl request for the get task API.
+     *
+     * @param request the get task request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetTaskRequest request) {
         final String taskId = request.getTaskId().getNodeId() + ":" + request.getTaskId().getId();
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_tasks/" + taskId);

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetViewAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetViewAction.java
@@ -22,15 +22,32 @@ import org.opensearch.action.admin.indices.view.GetViewAction;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the get view API over HTTP for OpenSearch,
+ * retrieving a view by its name.
+ */
 public class HttpGetViewAction extends HttpAction {
 
+    /** The get view action. */
     protected final GetViewAction action;
 
+    /**
+     * Creates a new HttpGetViewAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the get view action
+     */
     public HttpGetViewAction(final HttpClient client, final GetViewAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the get view request and notifies the listener with the response.
+     *
+     * @param request the get view request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final GetViewAction.Request request, final ActionListener<GetViewAction.Response> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -42,6 +59,12 @@ public class HttpGetViewAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the get view API.
+     *
+     * @param request the get view request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final GetViewAction.Request request) {
         // RestViewAction
         return client.getCurlRequest(GET, "/views/" + UrlUtils.encode(request.getName()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndexAction.java
@@ -37,15 +37,32 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
 
+/**
+ * Handles the index API over HTTP for OpenSearch/Elasticsearch,
+ * indexing a document into an index.
+ */
 public class HttpIndexAction extends HttpAction {
 
+    /** The index action. */
     protected final IndexAction action;
 
+    /**
+     * Creates a new HttpIndexAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the index action
+     */
     public HttpIndexAction(final HttpClient client, final IndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the index request and notifies the listener with the response.
+     *
+     * @param request the index request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final IndexRequest request, final ActionListener<IndexResponse> listener) {
         String source = null;
         try {
@@ -63,6 +80,13 @@ public class HttpIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses an index response from the given parser.
+     *
+     * @param parser the parser for the response body
+     * @return the parsed index response
+     * @throws IOException if the response cannot be parsed
+     */
     // IndexResponse.fromXContent(parser);
     protected IndexResponse fromXContent(final XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
@@ -74,6 +98,12 @@ public class HttpIndexAction extends HttpAction {
         return context.build();
     }
 
+    /**
+     * Builds the curl request for the index API.
+     *
+     * @param request the index request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndexRequest request) {
         // RestIndexAction
         final OpType opType = request.id() == null ? OpType.CREATE : request.opType();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
@@ -30,15 +30,32 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the indices aliases API over HTTP for OpenSearch/Elasticsearch,
+ * adding or removing index aliases.
+ */
 public class HttpIndicesAliasesAction extends HttpAction {
 
+    /** The indices aliases action. */
     protected final IndicesAliasesAction action;
 
+    /**
+     * Creates a new HttpIndicesAliasesAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the indices aliases action
+     */
     public HttpIndicesAliasesAction(final HttpClient client, final IndicesAliasesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the indices aliases request and notifies the listener with the response.
+     *
+     * @param request the indices aliases request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final IndicesAliasesRequest request, final ActionListener<AcknowledgedResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startArray("actions")) {
@@ -73,6 +90,12 @@ public class HttpIndicesAliasesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the indices aliases API.
+     *
+     * @param request the indices aliases request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndicesAliasesRequest request) {
         // RestIndicesAliasesAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_aliases");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesExistsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesExistsAction.java
@@ -23,15 +23,32 @@ import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.core.action.ActionListener;
 
+/**
+ * Handles the indices exists API over HTTP for OpenSearch/Elasticsearch,
+ * checking whether one or more indices exist.
+ */
 public class HttpIndicesExistsAction extends HttpAction {
 
+    /** The indices exists action. */
     protected final IndicesExistsAction action;
 
+    /**
+     * Creates a new HttpIndicesExistsAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the indices exists action
+     */
     public HttpIndicesExistsAction(final HttpClient client, final IndicesExistsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the indices exists request and notifies the listener with the response.
+     *
+     * @param request the indices exists request
+     * @param listener the listener to notify with the response or a failure
+     */
     public void execute(final IndicesExistsRequest request, final ActionListener<IndicesExistsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             final boolean exists = switch (response.getHttpStatusCode()) {
@@ -48,6 +65,12 @@ public class HttpIndicesExistsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the indices exists API.
+     *
+     * @param request the indices exists request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndicesExistsRequest request) {
         return client.getCurlRequest(HEAD, null, request.indices());
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesSegmentsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesSegmentsAction.java
@@ -27,15 +27,31 @@ import org.opensearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Indices Segments API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpIndicesSegmentsAction extends HttpAction {
 
+    /** The indices segments action definition. */
     protected final IndicesSegmentsAction action;
 
+    /**
+     * Creates a new HTTP indices segments action.
+     *
+     * @param client the HTTP client
+     * @param action the indices segments action definition
+     */
     public HttpIndicesSegmentsAction(final HttpClient client, final IndicesSegmentsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the indices segments request and notifies the listener with the response.
+     *
+     * @param request the indices segments request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final IndicesSegmentsRequest request, final ActionListener<IndicesSegmentResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -47,6 +63,13 @@ public class HttpIndicesSegmentsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the indices segments response from the XContent parser.
+     *
+     * @param parser the XContent parser positioned at the response body
+     * @return the parsed indices segments response
+     * @throws IOException if parsing fails
+     */
     protected IndicesSegmentResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -99,6 +122,12 @@ public class HttpIndicesSegmentsAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes and discards the current JSON object or array, including nested structures.
+     *
+     * @param parser the XContent parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -112,6 +141,12 @@ public class HttpIndicesSegmentsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the indices segments API.
+     *
+     * @param request the indices segments request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndicesSegmentsRequest request) {
         // RestIndicesSegmentsAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesShardStoresAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesShardStoresAction.java
@@ -30,15 +30,31 @@ import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Indices Shard Stores API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpIndicesShardStoresAction extends HttpAction {
 
+    /** The indices shard stores action definition. */
     protected final IndicesShardStoresAction action;
 
+    /**
+     * Creates a new HTTP indices shard stores action.
+     *
+     * @param client the HTTP client
+     * @param action the indices shard stores action definition
+     */
     public HttpIndicesShardStoresAction(final HttpClient client, final IndicesShardStoresAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the indices shard stores request and notifies the listener with the response.
+     *
+     * @param request the indices shard stores request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final IndicesShardStoresRequest request, final ActionListener<IndicesShardStoresResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -50,6 +66,14 @@ public class HttpIndicesShardStoresAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the indices shard stores response from the XContent parser.
+     * The store statuses are not parsed; an empty response is returned.
+     *
+     * @param parser the XContent parser positioned at the response body
+     * @return the parsed indices shard stores response
+     * @throws IOException if parsing fails
+     */
     protected IndicesShardStoresResponse fromXContent(final XContentParser parser) throws IOException {
         // Initialize parser - move to START_OBJECT
         XContentParser.Token token = parser.nextToken();
@@ -68,6 +92,12 @@ public class HttpIndicesShardStoresAction extends HttpAction {
         return new IndicesShardStoresResponse(Collections.emptyMap(), Collections.emptyList());
     }
 
+    /**
+     * Consumes and discards the current JSON object or array, including nested structures.
+     *
+     * @param parser the XContent parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -81,6 +111,12 @@ public class HttpIndicesShardStoresAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the indices shard stores API.
+     *
+     * @param request the indices shard stores request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndicesShardStoresRequest request) {
         // RestIndicesShardStoresAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesStatsAction.java
@@ -33,15 +33,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Indices Stats API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpIndicesStatsAction extends HttpAction {
 
+    /** The indices stats action definition. */
     protected IndicesStatsAction action;
 
+    /**
+     * Creates a new HTTP indices stats action.
+     *
+     * @param client the HTTP client
+     * @param action the indices stats action definition
+     */
     public HttpIndicesStatsAction(final HttpClient client, final IndicesStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the indices stats request and notifies the listener with the response.
+     *
+     * @param request the indices stats request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final IndicesStatsRequest request, final ActionListener<IndicesStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -53,6 +69,14 @@ public class HttpIndicesStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the indices stats response from the XContent parser.
+     * Only the shard summary is parsed; per-index stats are skipped.
+     *
+     * @param parser the XContent parser positioned at the response body
+     * @return the parsed indices stats response
+     * @throws IOException if parsing fails
+     */
     protected IndicesStatsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -102,6 +126,12 @@ public class HttpIndicesStatsAction extends HttpAction {
         return new IndicesStatsResponse(new ShardStats[0], totalShards, successfulShards, failedShards, shardFailures);
     }
 
+    /**
+     * Consumes and discards the current JSON object or array, including nested structures.
+     *
+     * @param parser the XContent parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -115,6 +145,12 @@ public class HttpIndicesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the indices stats API.
+     *
+     * @param request the indices stats request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final IndicesStatsRequest request) {
         final StringBuilder buf = new StringBuilder();
         if (request.indices() != null && request.indices().length > 0) {
@@ -149,6 +185,12 @@ public class HttpIndicesStatsAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Converts the stats flags to a comma-separated metric path segment.
+     *
+     * @param flags the common stats flags
+     * @return the comma-separated metric names, or an empty string if all metrics are set
+     */
     protected String getMetric(final CommonStatsFlags flags) {
         final List<String> metrics = new ArrayList<>();
         if (flags.isSet(Flag.Docs)) {

--- a/src/main/java/org/codelibs/fesen/client/action/HttpListTasksAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpListTasksAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the List Tasks API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpListTasksAction extends HttpAction {
 
+    /** The list tasks action definition. */
     protected final ListTasksAction action;
 
+    /**
+     * Creates a new HTTP list tasks action.
+     *
+     * @param client the HTTP client
+     * @param action the list tasks action definition
+     */
     public HttpListTasksAction(final HttpClient client, final ListTasksAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the list tasks request and notifies the listener with the response.
+     *
+     * @param request the list tasks request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final ListTasksRequest request, final ActionListener<ListTasksResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpListTasksAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the list tasks API.
+     *
+     * @param request the list tasks request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ListTasksRequest request) {
         // RestListTasksAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_tasks");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpListViewNamesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpListViewNamesAction.java
@@ -25,15 +25,31 @@ import org.opensearch.action.admin.indices.view.ListViewNamesAction;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the List View Names API over HTTP for OpenSearch.
+ */
 public class HttpListViewNamesAction extends HttpAction {
 
+    /** The list view names action definition. */
     protected final ListViewNamesAction action;
 
+    /**
+     * Creates a new HTTP list view names action.
+     *
+     * @param client the HTTP client
+     * @param action the list view names action definition
+     */
     public HttpListViewNamesAction(final HttpClient client, final ListViewNamesAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the list view names request and notifies the listener with the response.
+     *
+     * @param request the list view names request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final ListViewNamesAction.Request request, final ActionListener<ListViewNamesAction.Response> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -45,6 +61,13 @@ public class HttpListViewNamesAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the view names from the response body.
+     *
+     * @param parser the XContent parser positioned at the response body
+     * @return the list of view names
+     * @throws IOException if parsing fails
+     */
     protected List<String> parseViewNames(final XContentParser parser) throws IOException {
         final List<String> viewNames = new ArrayList<>();
         XContentParser.Token token = parser.nextToken();
@@ -59,6 +82,12 @@ public class HttpListViewNamesAction extends HttpAction {
         return viewNames;
     }
 
+    /**
+     * Builds the curl request for the list view names API.
+     *
+     * @param request the list view names request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ListViewNamesAction.Request request) {
         // RestViewAction
         return client.getCurlRequest(GET, "/views");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpMainAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpMainAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.main.MainResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Main (cluster info) API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpMainAction extends HttpAction {
 
+    /** The main action definition. */
     protected final MainAction action;
 
+    /**
+     * Creates a new HTTP main action.
+     *
+     * @param client the HTTP client
+     * @param action the main action definition
+     */
     public HttpMainAction(final HttpClient client, final MainAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the main request and notifies the listener with the response.
+     *
+     * @param request the main request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final MainRequest request, final ActionListener<MainResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpMainAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the main API.
+     *
+     * @param request the main request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final MainRequest request) {
         return client.getCurlRequest(POST, "/_xpack");
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpMultiGetAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpMultiGetAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Multi Get API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpMultiGetAction extends HttpAction {
 
+    /** The multi get action definition. */
     protected final MultiGetAction action;
 
+    /**
+     * Creates a new HTTP multi get action.
+     *
+     * @param client the HTTP client
+     * @param action the multi get action definition
+     */
     public HttpMultiGetAction(final HttpClient client, final MultiGetAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the multi get request and notifies the listener with the response.
+     *
+     * @param request the multi get request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final MultiGetRequest request, final ActionListener<MultiGetResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -57,6 +73,12 @@ public class HttpMultiGetAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the multi get API.
+     *
+     * @param request the multi get request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final MultiGetRequest request) {
         // RestMultiGetAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_mget");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpMultiSearchAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpMultiSearchAction.java
@@ -37,15 +37,31 @@ import org.opensearch.core.xcontent.XContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Multi Search API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpMultiSearchAction extends HttpAction {
 
+    /** The multi search action definition. */
     protected final MultiSearchAction action;
 
+    /**
+     * Creates a new HTTP multi search action.
+     *
+     * @param client the HTTP client
+     * @param action the multi search action definition
+     */
     public HttpMultiSearchAction(final HttpClient client, final MultiSearchAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the multi search request and notifies the listener with the response.
+     *
+     * @param request the multi search request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final MultiSearchRequest request, final ActionListener<MultiSearchResponse> listener) {
         String source = null;
         try {
@@ -63,6 +79,14 @@ public class HttpMultiSearchAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Serializes the multi search request into the newline-delimited (NDJSON) multi-line format.
+     *
+     * @param multiSearchRequest the multi search request to serialize
+     * @param xContent the content type used for serialization
+     * @return the serialized request body bytes
+     * @throws IOException if serialization fails
+     */
     // MultiSearchRequest.writeMultiLineFormat(request, XContentFactory.xContent(XContentType.JSON))
     protected byte[] writeMultiLineFormat(final MultiSearchRequest multiSearchRequest, final XContent xContent) throws IOException {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -86,6 +110,14 @@ public class HttpMultiSearchAction extends HttpAction {
         return output.toByteArray();
     }
 
+    /**
+     * Writes the header line parameters of a single search request, adjusting the output
+     * for the target engine type (Elasticsearch 8 and OpenSearch 2 use a custom format).
+     *
+     * @param request the search request
+     * @param xContentBuilder the builder to write the parameters to
+     * @throws IOException if writing fails
+     */
     //  MultiSearchRequest.writeSearchRequestParams(request, xContentBuilder)
     protected void writeSearchRequestParams(final SearchRequest request, final XContentBuilder xContentBuilder) throws IOException {
         final EngineType engineType = client.getEngineInfo().getType();
@@ -124,6 +156,12 @@ public class HttpMultiSearchAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the multi search API.
+     *
+     * @param request the multi search request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final MultiSearchRequest request) {
         // RestMultiSearchAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, ContentType.X_NDJSON, "/_msearch");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpMultiTermVectorsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpMultiTermVectorsAction.java
@@ -33,15 +33,31 @@ import org.opensearch.action.termvectors.TermVectorsResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the Multi Term Vectors API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpMultiTermVectorsAction extends HttpAction {
 
+    /** The multi term vectors action definition. */
     protected final MultiTermVectorsAction action;
 
+    /**
+     * Creates a new HTTP multi term vectors action.
+     *
+     * @param client the HTTP client
+     * @param action the multi term vectors action definition
+     */
     public HttpMultiTermVectorsAction(final HttpClient client, final MultiTermVectorsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the multi term vectors request and notifies the listener with the response.
+     *
+     * @param request the multi term vectors request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final MultiTermVectorsRequest request, final ActionListener<MultiTermVectorsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -53,6 +69,13 @@ public class HttpMultiTermVectorsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the multi term vectors response from the XContent parser.
+     *
+     * @param parser the XContent parser positioned at the response body
+     * @return the parsed multi term vectors response
+     * @throws IOException if parsing fails
+     */
     protected MultiTermVectorsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         final List<MultiTermVectorsItemResponse> items = new ArrayList<>();
@@ -79,6 +102,13 @@ public class HttpMultiTermVectorsAction extends HttpAction {
         return new MultiTermVectorsResponse(items.toArray(new MultiTermVectorsItemResponse[0]));
     }
 
+    /**
+     * Parses a single item from the docs array of the multi term vectors response.
+     *
+     * @param parser the XContent parser positioned at the item object
+     * @return the parsed item response
+     * @throws IOException if parsing fails
+     */
     protected MultiTermVectorsItemResponse parseItem(final XContentParser parser) throws IOException {
         String fieldName = null;
         String index = "";
@@ -119,6 +149,12 @@ public class HttpMultiTermVectorsAction extends HttpAction {
         return new MultiTermVectorsItemResponse(tvResponse, null);
     }
 
+    /**
+     * Consumes and discards the current JSON object or array, including nested structures.
+     *
+     * @param parser the XContent parser positioned inside the object or array to skip
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -132,6 +168,12 @@ public class HttpMultiTermVectorsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the multi term vectors API, including the request body.
+     *
+     * @param request the multi term vectors request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final MultiTermVectorsRequest request) {
         // Determine common index if all requests share the same index
         final List<TermVectorsRequest> requests = request.getRequests();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesHotThreadsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesHotThreadsAction.java
@@ -33,15 +33,32 @@ import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.action.ActionListener;
 
+/**
+ * Handles the Nodes Hot Threads API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpNodesHotThreadsAction extends HttpAction {
 
+    /** The nodes hot threads action definition. */
     protected NodesHotThreadsAction action;
 
+    /**
+     * Creates a new HTTP nodes hot threads action.
+     *
+     * @param client the HTTP client
+     * @param action the nodes hot threads action definition
+     */
     public HttpNodesHotThreadsAction(final HttpClient client, final NodesHotThreadsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the nodes hot threads request and notifies the listener with the response
+     * parsed from the plain-text hot threads output.
+     *
+     * @param request the nodes hot threads request
+     * @param listener the listener to notify with the response or failure
+     */
     public void execute(final NodesHotThreadsRequest request, final ActionListener<NodesHotThreadsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getContentAsStream(), StandardCharsets.UTF_8))) {
@@ -71,6 +88,13 @@ public class HttpNodesHotThreadsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a discovery node from a hot threads node header line (starting with ":::"),
+     * extracting the values enclosed in curly braces. Missing values are replaced with defaults.
+     *
+     * @param line the node header line
+     * @return the parsed discovery node
+     */
     protected DiscoveryNode parseDiscoveryNode(final String line) {
         final List<String> list = new ArrayList<>();
         boolean isTarget = false;
@@ -119,6 +143,12 @@ public class HttpNodesHotThreadsAction extends HttpAction {
                 Collections.emptySet(), Version.V_EMPTY);
     }
 
+    /**
+     * Builds the curl request for the nodes hot threads API.
+     *
+     * @param request the nodes hot threads request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final NodesHotThreadsRequest request) {
         // RestNodesHotThreadsAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesInfoAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesInfoAction.java
@@ -37,15 +37,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the nodes info API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpNodesInfoAction extends HttpAction {
 
+    /** The nodes info action definition. */
     protected final NodesInfoAction action;
 
+    /**
+     * Creates a new HttpNodesInfoAction.
+     *
+     * @param client the HTTP client
+     * @param action the nodes info action
+     */
     public HttpNodesInfoAction(final HttpClient client, final NodesInfoAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the nodes info request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the nodes info request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final NodesInfoRequest request, final ActionListener<NodesInfoResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -57,6 +73,13 @@ public class HttpNodesInfoAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a nodes info response from the response content.
+     *
+     * @param parser the content parser
+     * @return the nodes info response
+     * @throws IOException if parsing fails
+     */
     protected NodesInfoResponse fromXContent(final XContentParser parser) throws IOException {
         List<NodeInfo> nodes = Collections.emptyList();
         String fieldName = null;
@@ -89,6 +112,13 @@ public class HttpNodesInfoAction extends HttpAction {
         return new NodesInfoResponse(clusterName, nodes, Collections.emptyList());
     }
 
+    /**
+     * Parses the nodes section into a list of node information.
+     *
+     * @param parser the content parser
+     * @return the list of node information
+     * @throws IOException if parsing fails
+     */
     protected List<NodeInfo> parseNodes(final XContentParser parser) throws IOException {
         final List<NodeInfo> list = new ArrayList<>();
         String fieldName = null;
@@ -105,6 +135,14 @@ public class HttpNodesInfoAction extends HttpAction {
         return list;
     }
 
+    /**
+     * Parses information for a single node.
+     *
+     * @param parser the content parser
+     * @param nodeId the node identifier
+     * @return the node information
+     * @throws IOException if parsing fails
+     */
     protected NodeInfo parseNodeInfo(final XContentParser parser, final String nodeId) throws IOException {
         String fieldName = null;
         String nodeName = nodeId;
@@ -148,6 +186,12 @@ public class HttpNodesInfoAction extends HttpAction {
         return NodeInfo.builder(Version.CURRENT, Build.CURRENT, discoveryNode).build();
     }
 
+    /**
+     * Consumes and discards the current object, including any nested objects and arrays.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -161,6 +205,12 @@ public class HttpNodesInfoAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes and discards the current array, including any nested objects and arrays.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeArray(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -174,6 +224,12 @@ public class HttpNodesInfoAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the CURL request for the nodes info request.
+     *
+     * @param request the nodes info request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final NodesInfoRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_nodes");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
@@ -117,12 +117,23 @@ import org.opensearch.tasks.TaskCancellationStats;
 import org.opensearch.threadpool.ThreadPoolStats;
 import org.opensearch.transport.TransportStats;
 
+/**
+ * Handles the nodes stats API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpNodesStatsAction extends HttpAction {
 
+    /** The nodes stats action definition. */
     protected NodesStatsAction action;
 
+    /** Node-scoped cluster settings used when constructing parsed statistics. */
     protected ClusterSettings clusterSettings;
 
+    /**
+     * Creates a new HttpNodesStatsAction and initializes node-scoped cluster settings used for parsing.
+     *
+     * @param client the HTTP client
+     * @param action the nodes stats action
+     */
     public HttpNodesStatsAction(final HttpClient client, final NodesStatsAction action) {
         super(client);
         this.action = action;
@@ -145,6 +156,12 @@ public class HttpNodesStatsAction extends HttpAction {
         this.clusterSettings = new ClusterSettings(client.settings(), new HashSet<>(nodeSettings.values()), Collections.emptySet());
     }
 
+    /**
+     * Executes the nodes stats request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the nodes stats request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final NodesStatsRequest request, final ActionListener<NodesStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -156,6 +173,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a nodes stats response from the response content.
+     *
+     * @param parser the content parser
+     * @return the nodes stats response
+     * @throws IOException if parsing fails
+     */
     protected NodesStatsResponse fromXContent(final XContentParser parser) throws IOException {
         List<NodeStats> nodes = Collections.emptyList();
         String fieldName = null;
@@ -185,6 +209,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new NodesStatsResponse(clusterName, nodes, Collections.emptyList());
     }
 
+    /**
+     * Parses the nodes section into a list of node statistics.
+     *
+     * @param parser the content parser
+     * @return the list of node statistics
+     * @throws IOException if parsing fails
+     */
     protected List<NodeStats> parseNodes(final XContentParser parser) throws IOException {
         final List<NodeStats> list = new ArrayList<>();
         String fieldName = null;
@@ -204,6 +235,14 @@ public class HttpNodesStatsAction extends HttpAction {
         return list;
     }
 
+    /**
+     * Parses statistics for a single node.
+     *
+     * @param parser the content parser
+     * @param nodeId the node identifier
+     * @return the node statistics
+     * @throws IOException if parsing fails
+     */
     protected NodeStats parseNodeStats(final XContentParser parser, final String nodeId) throws IOException {
         String fieldName = null;
         String nodeName = "";
@@ -398,6 +437,12 @@ public class HttpNodesStatsAction extends HttpAction {
                 totalEstimatedNativeBytes);
     }
 
+    /**
+     * Parses a transport address string such as host:port into a transport address. Returns a placeholder address if parsing fails.
+     *
+     * @param addr the transport address string
+     * @return the parsed transport address
+     */
     public static TransportAddress parseTransportAddress(final String addr) {
         try {
             if (addr.startsWith("[")) {
@@ -419,26 +464,61 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes the adaptive selection section and returns empty adaptive selection statistics.
+     *
+     * @param parser the content parser
+     * @return the adaptive selection statistics
+     * @throws IOException if parsing fails
+     */
     protected AdaptiveSelectionStats parseAdaptiveSelectionStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new AdaptiveSelectionStats(Collections.emptyMap(), Collections.emptyMap());
     }
 
+    /**
+     * Consumes the script cache section and returns empty script cache statistics.
+     *
+     * @param parser the content parser
+     * @return the script cache statistics
+     * @throws IOException if parsing fails
+     */
     protected ScriptCacheStats parseScriptCacheStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new ScriptCacheStats(Collections.emptyMap());
     }
 
+    /**
+     * Consumes the indexing pressure section and returns empty indexing pressure statistics.
+     *
+     * @param parser the content parser
+     * @return the indexing pressure statistics
+     * @throws IOException if parsing fails
+     */
     protected IndexingPressureStats parseIndexingPressureStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new IndexingPressureStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
+    /**
+     * Consumes the shard indexing pressure section and returns empty shard indexing pressure statistics.
+     *
+     * @param parser the content parser
+     * @return the shard indexing pressure statistics
+     * @throws IOException if parsing fails
+     */
     protected ShardIndexingPressureStats parseShardIndexingPressureStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new ShardIndexingPressureStats(Collections.emptyMap(), 0, 0, 0, false, false);
     }
 
+    /**
+     * Parses search backpressure statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the search backpressure statistics
+     * @throws IOException if parsing fails
+     */
     protected SearchBackpressureStats parseSearchBackpressureStats(final XContentParser parser) throws IOException {
         SearchBackpressureMode mode = SearchBackpressureMode.DISABLED;
         SearchTaskStats searchTaskStats = new SearchTaskStats(0, 0, 0, Collections.emptyMap());
@@ -465,11 +545,25 @@ public class HttpNodesStatsAction extends HttpAction {
         return new SearchBackpressureStats(searchTaskStats, searchShardTaskStats, mode);
     }
 
+    /**
+     * Consumes the cluster manager throttling section and returns empty throttling statistics.
+     *
+     * @param parser the content parser
+     * @return the cluster manager throttling statistics
+     * @throws IOException if parsing fails
+     */
     protected ClusterManagerThrottlingStats parseClusterManagerThrottlingStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new ClusterManagerThrottlingStats();
     }
 
+    /**
+     * Parses weighted routing statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the weighted routing statistics
+     * @throws IOException if parsing fails
+     */
     protected WeightedRoutingStats parseWeightedRoutingStats(final XContentParser parser) throws IOException {
         int failOpenCount = 0;
         String fieldName = null;
@@ -490,6 +584,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return stats;
     }
 
+    /**
+     * Parses the fail open count from the weighted routing stats section.
+     *
+     * @param parser the content parser
+     * @return the fail open count
+     * @throws IOException if parsing fails
+     */
     protected int parseFailOpenCount(final XContentParser parser) throws IOException {
         int failOpenCount = 0;
         String fieldName = null;
@@ -505,6 +606,14 @@ public class HttpNodesStatsAction extends HttpAction {
         return failOpenCount;
     }
 
+    /**
+     * Parses file cache statistics from the response content.
+     *
+     * @param parser the content parser
+     * @param statsType the file cache stats type
+     * @return the file cache statistics
+     * @throws IOException if parsing fails
+     */
     protected FileCacheStats parseFileCacheStats(final XContentParser parser, final FileCacheStatsType statsType) throws IOException {
         long active = 0;
         long total = 0;
@@ -543,6 +652,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new FileCacheStats(active, total, used, pinned, evicted, removed, hits, misses, statsType);
     }
 
+    /**
+     * Parses aggregate file cache statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the aggregate file cache statistics
+     * @throws IOException if parsing fails
+     */
     protected AggregateFileCacheStats parseAggregateFileCacheStats(final XContentParser parser) throws IOException {
         long timestamp = 0;
         FileCacheStats fullFileStats = null;
@@ -586,6 +702,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new AggregateFileCacheStats(timestamp, overAllStats, fullFileStats, blockFileStats, pinnedFileStats);
     }
 
+    /**
+     * Parses block cache statistics from the over_all_stats section of the response content.
+     *
+     * @param parser the content parser
+     * @return the block cache statistics
+     * @throws IOException if parsing fails
+     */
     protected BlockCacheStats parseBlockCacheStats(final XContentParser parser) throws IOException {
         // Parse from over_all_stats sub-object; consume the other 3 sub-objects.
         // JSON fields available in over_all_stats:
@@ -640,6 +763,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new BlockCacheStats(hits, misses, 0L, 0L, 0L, evictionBytes, 0L, removedBytes, memoryBytesUsed, 0L, 0L, activeInBytes);
     }
 
+    /**
+     * Parses analytics backend native memory statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the analytics backend native memory statistics
+     * @throws IOException if parsing fails
+     */
     protected AnalyticsBackendNativeMemoryStats parseAnalyticsBackendNativeMemoryStats(final XContentParser parser) throws IOException {
         long allocatedBytes = 0;
         long residentBytes = 0;
@@ -660,6 +790,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new AnalyticsBackendNativeMemoryStats(allocatedBytes, residentBytes);
     }
 
+    /**
+     * Parses native allocator pool statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the native allocator pool statistics
+     * @throws IOException if parsing fails
+     */
     protected NativeAllocatorPoolStats parseNativeAllocatorPoolStats(final XContentParser parser) throws IOException {
         long rootAllocatedBytes = 0;
         long rootPeakBytes = 0;
@@ -730,6 +867,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new NativeAllocatorPoolStats(rootAllocatedBytes, rootPeakBytes, rootLimitBytes, pools);
     }
 
+    /**
+     * Parses task cancellation statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the task cancellation statistics
+     * @throws IOException if parsing fails
+     */
     protected TaskCancellationStats parseTaskCancellationStats(final XContentParser parser) throws IOException {
         SearchTaskCancellationStats searchTaskCancellationStats = null;
         SearchShardTaskCancellationStats searchShardTaskCancellationStats = null;
@@ -753,6 +897,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new TaskCancellationStats(searchTaskCancellationStats, searchShardTaskCancellationStats);
     }
 
+    /**
+     * Parses search task cancellation statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the search task cancellation statistics
+     * @throws IOException if parsing fails
+     */
     protected SearchTaskCancellationStats parseSearchTaskCancellationStats(final XContentParser parser) throws IOException {
         long currentLongRunningCancelledTaskCount = 0;
         long totalLongRunningCancelledTaskCount = 0;
@@ -773,6 +924,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new SearchTaskCancellationStats(currentLongRunningCancelledTaskCount, totalLongRunningCancelledTaskCount);
     }
 
+    /**
+     * Parses search shard task cancellation statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the search shard task cancellation statistics
+     * @throws IOException if parsing fails
+     */
     protected SearchShardTaskCancellationStats parseSearchShardTaskCancellationStats(final XContentParser parser) throws IOException {
         long currentLongRunningCancelledTaskCount = 0;
         long totalLongRunningCancelledTaskCount = 0;
@@ -793,6 +951,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new SearchShardTaskCancellationStats(currentLongRunningCancelledTaskCount, totalLongRunningCancelledTaskCount);
     }
 
+    /**
+     * Parses search pipeline statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the search pipeline statistics
+     * @throws IOException if parsing fails
+     */
     protected SearchPipelineStats parseSearchPipelineStats(final XContentParser parser) throws IOException {
         OperationStats totalRequestStats = null;
         OperationStats totalResponseStats = null;
@@ -818,6 +983,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new SearchPipelineStats(totalRequestStats, totalResponseStats, Collections.emptyList(), Collections.emptyMap(), null, null);
     }
 
+    /**
+     * Parses segment replication rejection statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the segment replication rejection statistics
+     * @throws IOException if parsing fails
+     */
     protected SegmentReplicationRejectionStats parseSegmentReplicationRejectionStats(final XContentParser parser) throws IOException {
         long totalRejectedRequests = 0;
         String fieldName = null;
@@ -835,11 +1007,25 @@ public class HttpNodesStatsAction extends HttpAction {
         return new SegmentReplicationRejectionStats(totalRejectedRequests);
     }
 
+    /**
+     * Consumes the remote store section and returns empty remote store node statistics.
+     *
+     * @param parser the content parser
+     * @return the remote store node statistics
+     * @throws IOException if parsing fails
+     */
     protected RemoteStoreNodeStats parseRemoteStoreNodeStats(final XContentParser parser) throws IOException {
         consumeObject(parser);
         return new RemoteStoreNodeStats();
     }
 
+    /**
+     * Parses operation statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the operation statistics
+     * @throws IOException if parsing fails
+     */
     protected OperationStats parseOperationStats(final XContentParser parser) throws IOException {
         long count = 0;
         long totalTimeInMillis = 0;
@@ -866,6 +1052,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new OperationStats(count, totalTimeInMillis, current, failedCount);
     }
 
+    /**
+     * Parses ingest statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the ingest statistics
+     * @throws IOException if parsing fails
+     */
     protected IngestStats parseIngestStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         OperationStats totalStats = null;
@@ -939,6 +1132,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new IngestStats(totalStats, pipelineStats, Collections.emptyMap());
     }
 
+    /**
+     * Parses discovery statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the discovery statistics
+     * @throws IOException if parsing fails
+     */
     protected DiscoveryStats parseDiscoveryStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         PendingClusterStateStats queueStats = null;
@@ -965,6 +1165,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new DiscoveryStats(queueStats, publishStats, clusterStateStats);
     }
 
+    /**
+     * Parses cluster state statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the cluster state statistics
+     * @throws IOException if parsing fails
+     */
     protected ClusterStateStats parseClusterStateStats(XContentParser parser) throws IOException {
         String fieldName = null;
         long updateSuccess = 0;
@@ -1008,6 +1215,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses published cluster state statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the published cluster state statistics
+     * @throws IOException if parsing fails
+     */
     protected PublishClusterStateStats parsePublishClusterStateStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long fullClusterStateReceivedCount = 0;
@@ -1032,6 +1246,13 @@ public class HttpNodesStatsAction extends HttpAction {
                 compatibleClusterStateDiffReceivedCount);
     }
 
+    /**
+     * Parses pending cluster state statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the pending cluster state statistics
+     * @throws IOException if parsing fails
+     */
     protected PendingClusterStateStats parsePendingClusterStateStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         int total = 0;
@@ -1055,6 +1276,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new PendingClusterStateStats(total, pending, committed);
     }
 
+    /**
+     * Parses script statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the script statistics
+     * @throws IOException if parsing fails
+     */
     protected ScriptStats parseScriptStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long compilations = 0;
@@ -1078,6 +1306,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new ScriptStats(compilations, cacheEvictions, compilationLimitTriggered);
     }
 
+    /**
+     * Parses circuit breaker statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the circuit breaker statistics
+     * @throws IOException if parsing fails
+     */
     protected AllCircuitBreakerStats parseAllCircuitBreakerStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         final List<CircuitBreakerStats> allStats = new ArrayList<>();
@@ -1115,6 +1350,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new AllCircuitBreakerStats(allStats.toArray(new CircuitBreakerStats[allStats.size()]));
     }
 
+    /**
+     * Parses HTTP statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the HTTP statistics
+     * @throws IOException if parsing fails
+     */
     protected HttpStats parseHttpStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long serverOpen = 0;
@@ -1135,6 +1377,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new HttpStats(serverOpen, totalOpened);
     }
 
+    /**
+     * Parses transport statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the transport statistics
+     * @throws IOException if parsing fails
+     */
     protected TransportStats parseTransportStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long serverOpen = 0;
@@ -1167,6 +1416,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new TransportStats(serverOpen, totalOutboundConnections, rxCount, rxSize, txCount, txSize);
     }
 
+    /**
+     * Parses file system information from the response content.
+     *
+     * @param parser the content parser
+     * @return the file system information
+     * @throws IOException if parsing fails
+     */
     protected FsInfo parseFsInfo(final XContentParser parser) throws IOException {
         String fieldName = null;
         long timestamp = 0;
@@ -1221,6 +1477,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new FsInfo(timestamp, ioStats, paths.toArray(new FsInfo.Path[paths.size()]));
     }
 
+    /**
+     * Parses disk usage information from the response content.
+     *
+     * @param parser the content parser
+     * @return the disk usage
+     * @throws IOException if parsing fails
+     */
     protected DiskUsage parseFsInfoIskUsage(final XContentParser parser) throws IOException {
         String fieldName = null;
         final String nodeId = "";
@@ -1246,6 +1509,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new DiskUsage(nodeId, nodeName, path, totalBytes, freeBytes);
     }
 
+    /**
+     * Parses thread pool statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the thread pool statistics
+     * @throws IOException if parsing fails
+     */
     protected ThreadPoolStats parseThreadPoolStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         final List<ThreadPoolStats.Stats> stats = new ArrayList<>();
@@ -1292,6 +1562,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new ThreadPoolStats(stats);
     }
 
+    /**
+     * Parses JVM statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the JVM statistics
+     * @throws IOException if parsing fails
+     */
     protected JvmStats parseJvmStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long timestamp = 0;
@@ -1332,6 +1609,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new JvmStats(timestamp, uptime, mem, threads, gc, bufferPools, classes);
     }
 
+    /**
+     * Parses JVM class loading statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the JVM class loading statistics
+     * @throws IOException if parsing fails
+     */
     protected JvmStats.Classes parseJvmStatsClasses(final XContentParser parser) throws IOException {
         String fieldName = null;
         long loadedClassCount = 0;
@@ -1355,6 +1639,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new JvmStats.Classes(loadedClassCount, totalLoadedClassCount, unloadedClassCount);
     }
 
+    /**
+     * Parses JVM buffer pool statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the list of JVM buffer pool statistics
+     * @throws IOException if parsing fails
+     */
     protected List<JvmStats.BufferPool> parseJvmStatsBufferPools(final XContentParser parser) throws IOException {
         String fieldName = null;
         final List<JvmStats.BufferPool> bufferPools = new ArrayList<>();
@@ -1389,6 +1680,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return bufferPools;
     }
 
+    /**
+     * Parses JVM garbage collector statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the JVM garbage collector statistics
+     * @throws IOException if parsing fails
+     */
     protected JvmStats.GarbageCollectors parseJvmStatsGc(final XContentParser parser) throws IOException {
         String fieldName = null;
         final List<JvmStats.GarbageCollector> collectors = new ArrayList<>();
@@ -1432,6 +1730,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new JvmStats.GarbageCollectors(collectors.toArray(new JvmStats.GarbageCollector[collectors.size()]));
     }
 
+    /**
+     * Parses JVM thread statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the JVM thread statistics
+     * @throws IOException if parsing fails
+     */
     protected JvmStats.Threads parseJvmStatsThreads(final XContentParser parser) throws IOException {
         String fieldName = null;
         int count = 0;
@@ -1452,6 +1757,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new JvmStats.Threads(count, peakCount);
     }
 
+    /**
+     * Parses JVM memory statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the JVM memory statistics
+     * @throws IOException if parsing fails
+     */
     protected JvmStats.Mem parseJvmStatsMem(final XContentParser parser) throws IOException {
         String fieldName = null;
         long heapCommitted = 0;
@@ -1541,6 +1853,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new JvmStats.Mem(heapCommitted, heapUsed, heapMax, nonHeapCommitted, nonHeapUsed, pools);
     }
 
+    /**
+     * Parses process statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the process statistics
+     * @throws IOException if parsing fails
+     */
     protected ProcessStats parseProcessStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long timestamp = 0;
@@ -1575,6 +1894,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new ProcessStats(timestamp, openFileDescriptors, maxFileDescriptors, cpu, mem);
     }
 
+    /**
+     * Parses process memory statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the process memory statistics
+     * @throws IOException if parsing fails
+     */
     protected ProcessStats.Mem parseProcessStatsMem(final XContentParser parser) throws IOException {
         String fieldName = null;
         long totalVirtual = 0;
@@ -1590,6 +1916,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new ProcessStats.Mem(totalVirtual);
     }
 
+    /**
+     * Parses process CPU statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the process CPU statistics
+     * @throws IOException if parsing fails
+     */
     protected ProcessStats.Cpu parseProcessStatsCpu(final XContentParser parser) throws IOException {
         String fieldName = null;
         short percent = 0;
@@ -1610,6 +1943,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new ProcessStats.Cpu(percent, total);
     }
 
+    /**
+     * Parses operating system statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the operating system statistics
+     * @throws IOException if parsing fails
+     */
     protected OsStats parseOsStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long timestamp = 0;
@@ -1642,6 +1982,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new OsStats(timestamp, cpu, mem, swap, cgroup);
     }
 
+    /**
+     * Parses cgroup statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the cgroup statistics
+     * @throws IOException if parsing fails
+     */
     protected OsStats.Cgroup parseOsStatsCgroup(final XContentParser parser) throws IOException {
         String fieldName = null;
         String cpuAcctControlGroup = null;
@@ -1738,6 +2085,13 @@ public class HttpNodesStatsAction extends HttpAction {
                 memoryControlGroup, memoryLimitInBytes, memoryUsageInBytes);
     }
 
+    /**
+     * Parses swap statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the swap statistics
+     * @throws IOException if parsing fails
+     */
     protected OsStats.Swap parseOsStatsSwap(final XContentParser parser) throws IOException {
         String fieldName = null;
         long total = 0;
@@ -1758,6 +2112,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new OsStats.Swap(total, free);
     }
 
+    /**
+     * Parses operating system memory statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the operating system memory statistics
+     * @throws IOException if parsing fails
+     */
     protected OsStats.Mem parseOsStatsMem(final XContentParser parser) throws IOException {
         String fieldName = null;
         long total = 0;
@@ -1778,6 +2139,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new OsStats.Mem(total, free);
     }
 
+    /**
+     * Parses operating system CPU statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the operating system CPU statistics
+     * @throws IOException if parsing fails
+     */
     protected OsStats.Cpu parseOsStatsCpu(final XContentParser parser) throws IOException {
         String fieldName = null;
         short systemCpuPercent = 0;
@@ -1814,6 +2182,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new OsStats.Cpu(systemCpuPercent, systemLoadAverage);
     }
 
+    /**
+     * Parses node indices statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the node indices statistics
+     * @throws IOException if parsing fails
+     */
     protected NodeIndicesStats parseNodeIndicesStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         DocsStats docs = null;
@@ -1902,6 +2277,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses recovery statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the recovery statistics
+     * @throws IOException if parsing fails
+     */
     protected RecoveryStats parseRecoveryStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         int currentAsSource = 0;
@@ -1932,6 +2314,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses request cache statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the request cache statistics
+     * @throws IOException if parsing fails
+     */
     protected RequestCacheStats parseRequestCacheStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long memorySize = 0;
@@ -1958,6 +2347,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new RequestCacheStats(memorySize, evictions, hitCount, missCount);
     }
 
+    /**
+     * Parses translog statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the translog statistics
+     * @throws IOException if parsing fails
+     */
     protected TranslogStats parseTranslogStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         int numberOfOperations = 0;
@@ -1988,6 +2384,13 @@ public class HttpNodesStatsAction extends HttpAction {
                 earliestLastModifiedAge);
     }
 
+    /**
+     * Parses segment statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the segment statistics
+     * @throws IOException if parsing fails
+     */
     protected SegmentsStats parseSegmentsStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long count = 0;
@@ -2075,6 +2478,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses completion statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the completion statistics
+     * @throws IOException if parsing fails
+     */
     protected CompletionStats parseCompletionStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long size = 0;
@@ -2090,6 +2500,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new CompletionStats(size, null);
     }
 
+    /**
+     * Parses field data statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the field data statistics
+     * @throws IOException if parsing fails
+     */
     protected FieldDataStats parseFieldDataStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long memorySize = 0;
@@ -2110,6 +2527,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new FieldDataStats(memorySize, evictions, null);
     }
 
+    /**
+     * Parses query cache statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the query cache statistics
+     * @throws IOException if parsing fails
+     */
     protected QueryCacheStats parseQueryCacheStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long ramBytesUsed = 0;
@@ -2139,6 +2563,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new QueryCacheStats(ramBytesUsed, hitCount, missCount, cacheCount, cacheSize);
     }
 
+    /**
+     * Parses warmer statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the warmer statistics
+     * @throws IOException if parsing fails
+     */
     protected WarmerStats parseWarmerStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long current = 0;
@@ -2162,6 +2593,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new WarmerStats(current, total, totalTimeInMillis);
     }
 
+    /**
+     * Parses flush statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the flush statistics
+     * @throws IOException if parsing fails
+     */
     protected FlushStats parseFlushStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long total = 0;
@@ -2185,6 +2623,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new FlushStats(total, periodic, totalTimeInMillis);
     }
 
+    /**
+     * Parses refresh statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the refresh statistics
+     * @throws IOException if parsing fails
+     */
     protected RefreshStats parseRefreshStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long total = 0;
@@ -2214,6 +2659,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new RefreshStats(total, totalTimeInMillis, externalTotal, externalTotalTimeInMillis, listeners);
     }
 
+    /**
+     * Parses merge statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the merge statistics
+     * @throws IOException if parsing fails
+     */
     protected MergeStats parseMergeStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long total = 0;
@@ -2272,6 +2724,13 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses search statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the search statistics
+     * @throws IOException if parsing fails
+     */
     protected SearchStats parseSearchStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long queryCount = 0;
@@ -2373,6 +2832,13 @@ public class HttpNodesStatsAction extends HttpAction {
                 searchIdleReactivateCount), openContexts, null);
     }
 
+    /**
+     * Parses get statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the get statistics
+     * @throws IOException if parsing fails
+     */
     protected GetStats parseGetStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long existsCount = 0;
@@ -2402,6 +2868,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new GetStats(existsCount, existsTimeInMillis, missingCount, missingTimeInMillis, current);
     }
 
+    /**
+     * Parses indexing statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the indexing statistics
+     * @throws IOException if parsing fails
+     */
     protected IndexingStats parseIndexingStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long indexCount = 0;
@@ -2452,6 +2925,13 @@ public class HttpNodesStatsAction extends HttpAction {
                 deleteTimeInMillis, deleteCurrent, noopUpdateCount, isThrottled, throttleTimeInMillis, docStatusStats));
     }
 
+    /**
+     * Parses store statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the store statistics
+     * @throws IOException if parsing fails
+     */
     protected StoreStats parseStoreStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long sizeInBytes = 0;
@@ -2472,6 +2952,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new StoreStats(sizeInBytes, reservedSize);
     }
 
+    /**
+     * Parses document statistics from the response content.
+     *
+     * @param parser the content parser
+     * @return the document statistics
+     * @throws IOException if parsing fails
+     */
     protected DocsStats parseDocsStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long count = 0;
@@ -2495,6 +2982,13 @@ public class HttpNodesStatsAction extends HttpAction {
         return new DocsStats(count, deleted, totalSizeInBytes);
     }
 
+    /**
+     * Parses the _nodes result counts from the response content.
+     *
+     * @param parser the content parser
+     * @return an array containing total, successful, and failed node counts
+     * @throws IOException if parsing fails
+     */
     protected int[] parseNodeResults(final XContentParser parser) throws IOException {
         final int results[] = new int[3];
         String fieldName = null;
@@ -2516,6 +3010,12 @@ public class HttpNodesStatsAction extends HttpAction {
         return results;
     }
 
+    /**
+     * Consumes and discards the current object, including any nested objects and arrays.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
@@ -2532,6 +3032,12 @@ public class HttpNodesStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the metric path segment for the nodes stats endpoint from the requested metrics.
+     *
+     * @param request the nodes stats request
+     * @return the metric path segment
+     */
     protected String getMetric(final NodesStatsRequest request) {
         final Set<String> metrics = request.requestedMetrics();
         if (request.indices().anySet() && CommonStatsFlags.ALL.getFlags().length != request.indices().getFlags().length) {
@@ -2541,6 +3047,12 @@ public class HttpNodesStatsAction extends HttpAction {
         return metrics.stream().collect(Collectors.joining(","));
     }
 
+    /**
+     * Builds the CURL request for the nodes stats request.
+     *
+     * @param request the nodes stats request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final NodesStatsRequest request) {
         // RestNodesStatsAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesUsageAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesUsageAction.java
@@ -35,15 +35,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the nodes usage API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpNodesUsageAction extends HttpAction {
 
+    /** The nodes usage action definition. */
     protected final NodesUsageAction action;
 
+    /**
+     * Creates a new HttpNodesUsageAction.
+     *
+     * @param client the HTTP client
+     * @param action the nodes usage action
+     */
     public HttpNodesUsageAction(final HttpClient client, final NodesUsageAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the nodes usage request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the nodes usage request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final NodesUsageRequest request, final ActionListener<NodesUsageResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -55,6 +71,13 @@ public class HttpNodesUsageAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a nodes usage response from the response content.
+     *
+     * @param parser the content parser
+     * @return the nodes usage response
+     * @throws IOException if parsing fails
+     */
     protected NodesUsageResponse fromXContent(final XContentParser parser) throws IOException {
         List<NodeUsage> nodes = Collections.emptyList();
         String fieldName = null;
@@ -87,6 +110,13 @@ public class HttpNodesUsageAction extends HttpAction {
         return new NodesUsageResponse(clusterName, nodes, Collections.emptyList());
     }
 
+    /**
+     * Parses the nodes section into a list of node usage information.
+     *
+     * @param parser the content parser
+     * @return the list of node usage information
+     * @throws IOException if parsing fails
+     */
     protected List<NodeUsage> parseNodes(final XContentParser parser) throws IOException {
         final List<NodeUsage> list = new ArrayList<>();
         String fieldName = null;
@@ -103,6 +133,14 @@ public class HttpNodesUsageAction extends HttpAction {
         return list;
     }
 
+    /**
+     * Parses usage information for a single node.
+     *
+     * @param parser the content parser
+     * @param nodeId the node identifier
+     * @return the node usage information
+     * @throws IOException if parsing fails
+     */
     protected NodeUsage parseNodeUsage(final XContentParser parser, final String nodeId) throws IOException {
         String fieldName = null;
         long timestamp = 0;
@@ -138,6 +176,13 @@ public class HttpNodesUsageAction extends HttpAction {
         return new NodeUsage(node, timestamp, sinceTime, restUsage, aggregationUsage);
     }
 
+    /**
+     * Parses REST action usage counts.
+     *
+     * @param parser the content parser
+     * @return a map of REST action names to usage counts
+     * @throws IOException if parsing fails
+     */
     protected Map<String, Long> parseRestActions(final XContentParser parser) throws IOException {
         final Map<String, Long> restActions = new HashMap<>();
         XContentParser.Token token;
@@ -153,6 +198,12 @@ public class HttpNodesUsageAction extends HttpAction {
         return restActions;
     }
 
+    /**
+     * Consumes and discards the current object, including any nested objects and arrays.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -166,6 +217,12 @@ public class HttpNodesUsageAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the CURL request for the nodes usage request.
+     *
+     * @param request the nodes usage request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final NodesUsageRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_nodes");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpOpenIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpOpenIndexAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the open index API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpOpenIndexAction extends HttpAction {
 
+    /** The open index action definition. */
     protected final OpenIndexAction action;
 
+    /**
+     * Creates a new HttpOpenIndexAction.
+     *
+     * @param client the HTTP client
+     * @param action the open index action
+     */
     public HttpOpenIndexAction(final HttpClient client, final OpenIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the open index request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the open index request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final OpenIndexRequest request, final ActionListener<OpenIndexResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpOpenIndexAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the open index request.
+     *
+     * @param request the open index request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final OpenIndexRequest request) {
         // RestOpenIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_open", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPauseIngestionAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPauseIngestionAction.java
@@ -26,15 +26,31 @@ import org.opensearch.action.admin.indices.streamingingestion.pause.PauseIngesti
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the pause ingestion API over HTTP for OpenSearch.
+ */
 public class HttpPauseIngestionAction extends HttpAction {
 
+    /** The pause ingestion action definition. */
     protected final PauseIngestionAction action;
 
+    /**
+     * Creates a new HttpPauseIngestionAction.
+     *
+     * @param client the HTTP client
+     * @param action the pause ingestion action
+     */
     public HttpPauseIngestionAction(final HttpClient client, final PauseIngestionAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the pause ingestion request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the pause ingestion request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PauseIngestionRequest request, final ActionListener<PauseIngestionResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -46,6 +62,13 @@ public class HttpPauseIngestionAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a pause ingestion response from the response content.
+     *
+     * @param parser the content parser
+     * @return the pause ingestion response
+     * @throws IOException if parsing fails
+     */
     protected PauseIngestionResponse fromXContent(final XContentParser parser) throws IOException {
         boolean acknowledged = false;
         boolean shardsAcknowledged = false;
@@ -72,6 +95,12 @@ public class HttpPauseIngestionAction extends HttpAction {
         return new PauseIngestionResponse(acknowledged, shardsAcknowledged, new IngestionStateShardFailure[0], "");
     }
 
+    /**
+     * Consumes and discards the current object, including any nested objects and arrays.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -85,6 +114,12 @@ public class HttpPauseIngestionAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the CURL request for the pause ingestion request.
+     *
+     * @param request the pause ingestion request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PauseIngestionRequest request) {
         // RestPauseIngestionAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/ingestion/_pause", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPendingClusterTasksAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPendingClusterTasksAction.java
@@ -32,15 +32,31 @@ import org.opensearch.core.common.text.Text;
 import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the pending cluster tasks API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPendingClusterTasksAction extends HttpAction {
 
+    /** The pending cluster tasks action definition. */
     protected final PendingClusterTasksAction action;
 
+    /**
+     * Creates a new HttpPendingClusterTasksAction.
+     *
+     * @param client the HTTP client
+     * @param action the pending cluster tasks action
+     */
     public HttpPendingClusterTasksAction(final HttpClient client, final PendingClusterTasksAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the pending cluster tasks request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the pending cluster tasks request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PendingClusterTasksRequest request, final ActionListener<PendingClusterTasksResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -52,6 +68,12 @@ public class HttpPendingClusterTasksAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the pending cluster tasks request.
+     *
+     * @param request the pending cluster tasks request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PendingClusterTasksRequest request) {
         // RestPendingClusterTasksAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_cluster/pending_tasks");
@@ -62,6 +84,12 @@ public class HttpPendingClusterTasksAction extends HttpAction {
         return curlRequest;
     }
 
+    /**
+     * Parses a pending cluster tasks response from the response content.
+     *
+     * @param parser the content parser
+     * @return the pending cluster tasks response
+     */
     protected PendingClusterTasksResponse getPendingClusterTasksResponse(final XContentParser parser) {
         @SuppressWarnings("unchecked")
         final ConstructingObjectParser<PendingClusterTasksResponse, Void> objectParser =
@@ -85,6 +113,11 @@ public class HttpPendingClusterTasksAction extends HttpAction {
         return objectParser.apply(parser, null);
     }
 
+    /**
+     * Creates an object parser for a single pending cluster task.
+     *
+     * @return the pending cluster task parser
+     */
     protected ConstructingObjectParser<PendingClusterTask, Void> getPendingClusterTaskParser() {
         final ConstructingObjectParser<PendingClusterTask, Void> objectParser =
                 new ConstructingObjectParser<>("tasks", true, a -> new PendingClusterTask((long) a[0], Priority.valueOf((String) a[1]),

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutIndexTemplateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutIndexTemplateAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the put index template API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPutIndexTemplateAction extends HttpAction {
 
+    /** The put index template action definition. */
     protected final PutIndexTemplateAction action;
 
+    /**
+     * Creates a new HttpPutIndexTemplateAction.
+     *
+     * @param client the HTTP client
+     * @param action the put index template action
+     */
     public HttpPutIndexTemplateAction(final HttpClient client, final PutIndexTemplateAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the put index template request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the put index template request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PutIndexTemplateRequest request, final ActionListener<AcknowledgedResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -58,6 +74,12 @@ public class HttpPutIndexTemplateAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the put index template request.
+     *
+     * @param request the put index template request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PutIndexTemplateRequest request) {
         // RestPutIndexTemplateAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/_template/" + UrlUtils.encode(request.name()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the put mapping API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPutMappingAction extends HttpAction {
 
+    /** The put mapping action definition. */
     protected final PutMappingAction action;
 
+    /**
+     * Creates a new HttpPutMappingAction.
+     *
+     * @param client the HTTP client
+     * @param action the put mapping action
+     */
     public HttpPutMappingAction(final HttpClient client, final PutMappingAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the put mapping request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the put mapping request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PutMappingRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).body(request.source()).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpPutMappingAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the put mapping request.
+     *
+     * @param request the put mapping request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PutMappingRequest request) {
         // RestPutMappingAction
         final String path = "/_mapping";

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutPipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutPipelineAction.java
@@ -28,15 +28,31 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the put pipeline API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPutPipelineAction extends HttpAction {
 
+    /** The put pipeline action definition. */
     protected final PutPipelineAction action;
 
+    /**
+     * Creates a new HttpPutPipelineAction.
+     *
+     * @param client the HTTP client
+     * @param action the put pipeline action
+     */
     public HttpPutPipelineAction(final HttpClient client, final PutPipelineAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the put pipeline request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the put pipeline request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PutPipelineRequest request, final ActionListener<AcknowledgedResponse> listener) {
         String source = null;
         try {
@@ -54,6 +70,12 @@ public class HttpPutPipelineAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the put pipeline request.
+     *
+     * @param request the put pipeline request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PutPipelineRequest request) {
         // RestPutPipelineAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/_ingest/pipeline/" + UrlUtils.encode(request.getId()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the put repository API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPutRepositoryAction extends HttpAction {
 
+    /** The put repository action definition. */
     protected final PutRepositoryAction action;
 
+    /**
+     * Creates a new HttpPutRepositoryAction.
+     *
+     * @param client the HTTP client
+     * @param action the put repository action
+     */
     public HttpPutRepositoryAction(final HttpClient client, final PutRepositoryAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the put repository request asynchronously and notifies the listener with the response or failure.
+     *
+     * @param request the put repository request
+     * @param listener the listener notified with the response or failure
+     */
     public void execute(final PutRepositoryRequest request, final ActionListener<AcknowledgedResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpPutRepositoryAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the CURL request for the put repository request.
+     *
+     * @param request the put repository request
+     * @return the CURL request
+     */
     protected CurlRequest getCurlRequest(final PutRepositoryRequest request) {
         // RestPutRepositoryAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/_snapshot/" + UrlUtils.encode(request.name()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutStoredScriptAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutStoredScriptAction.java
@@ -28,15 +28,31 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the put stored script API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpPutStoredScriptAction extends HttpAction {
 
+    /** The put stored script action. */
     protected final PutStoredScriptAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the put stored script action
+     */
     public HttpPutStoredScriptAction(final HttpClient client, final PutStoredScriptAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the put stored script request and notifies the listener with the response.
+     *
+     * @param request the put stored script request
+     * @param listener the listener to be notified with the acknowledged response or a failure
+     */
     public void execute(final PutStoredScriptRequest request, final ActionListener<AcknowledgedResponse> listener) {
         String source = null;
         try {
@@ -54,6 +70,12 @@ public class HttpPutStoredScriptAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds a curl request for the put stored script request.
+     *
+     * @param request the put stored script request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final PutStoredScriptRequest request) {
         // RestPutStoredScriptAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_scripts/" + UrlUtils.encode(request.id()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRecoveryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRecoveryAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the indices recovery API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRecoveryAction extends HttpAction {
 
+    /** The recovery action. */
     protected final RecoveryAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the recovery action
+     */
     public HttpRecoveryAction(final HttpClient client, final RecoveryAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the recovery request and notifies the listener with the response.
+     *
+     * @param request the recovery request
+     * @param listener the listener to be notified with the recovery response or a failure
+     */
     public void execute(final RecoveryRequest request, final ActionListener<RecoveryResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -50,6 +66,13 @@ public class HttpRecoveryAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a recovery response from the given parser, counting shards per index.
+     *
+     * @param parser the content parser
+     * @return the parsed recovery response
+     * @throws IOException if parsing fails
+     */
     protected RecoveryResponse fromXContent(final XContentParser parser) throws IOException {
         // Initialize parser - move to START_OBJECT
         XContentParser.Token token = parser.nextToken();
@@ -71,6 +94,13 @@ public class HttpRecoveryAction extends HttpAction {
         return new RecoveryResponse(totalShards, totalShards, 0, Collections.emptyMap(), new ArrayList<>());
     }
 
+    /**
+     * Counts the entries of the shards array in an index object and consumes the remaining content.
+     *
+     * @param parser the content parser positioned at the start of an index object
+     * @return the number of shard entries
+     * @throws IOException if parsing fails
+     */
     protected int countShardsAndConsume(final XContentParser parser) throws IOException {
         int shardCount = 0;
         XContentParser.Token token;
@@ -92,6 +122,12 @@ public class HttpRecoveryAction extends HttpAction {
         return shardCount;
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -105,6 +141,12 @@ public class HttpRecoveryAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds a curl request for the recovery request.
+     *
+     * @param request the recovery request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RecoveryRequest request) {
         // RestRecoveryAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRefreshAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRefreshAction.java
@@ -23,15 +23,31 @@ import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the indices refresh API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRefreshAction extends HttpAction {
 
+    /** The refresh action. */
     protected final RefreshAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the refresh action
+     */
     public HttpRefreshAction(final HttpClient client, final RefreshAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the refresh request and notifies the listener with the response.
+     *
+     * @param request the refresh request
+     * @param listener the listener to be notified with the refresh response or a failure
+     */
     public void execute(final RefreshRequest request, final ActionListener<RefreshResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -43,6 +59,12 @@ public class HttpRefreshAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds a curl request for the refresh request.
+     *
+     * @param request the refresh request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RefreshRequest request) {
         return client.getCurlRequest(POST, "/_refresh", request.indices());
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRemoteInfoAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRemoteInfoAction.java
@@ -26,15 +26,31 @@ import org.opensearch.action.admin.cluster.remote.RemoteInfoResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the remote cluster info API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRemoteInfoAction extends HttpAction {
 
+    /** The remote info action. */
     protected final RemoteInfoAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the remote info action
+     */
     public HttpRemoteInfoAction(final HttpClient client, final RemoteInfoAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the remote info request and notifies the listener with the response.
+     *
+     * @param request the remote info request
+     * @param listener the listener to be notified with the remote info response or a failure
+     */
     public void execute(final RemoteInfoRequest request, final ActionListener<RemoteInfoResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -46,6 +62,14 @@ public class HttpRemoteInfoAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a remote info response from the given parser. The response body is consumed and an
+     * empty connection list is returned because RemoteConnectionInfo cannot be constructed externally.
+     *
+     * @param parser the content parser
+     * @return a remote info response with an empty connection list
+     * @throws IOException if parsing fails
+     */
     protected RemoteInfoResponse fromXContent(final XContentParser parser) throws IOException {
         // RemoteConnectionInfo requires complex ModeInfo construction
         // Return empty list - callers can use the REST API directly for full details
@@ -56,6 +80,12 @@ public class HttpRemoteInfoAction extends HttpAction {
         return new RemoteInfoResponse(Collections.emptyList());
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -69,6 +99,12 @@ public class HttpRemoteInfoAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds a curl request for the remote info request.
+     *
+     * @param request the remote info request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RemoteInfoRequest request) {
         return client.getCurlRequest(GET, "/_remote/info");
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRemoteStoreMetadataAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRemoteStoreMetadataAction.java
@@ -32,15 +32,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the remote store metadata API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRemoteStoreMetadataAction extends HttpAction {
 
+    /** The remote store metadata action. */
     protected RemoteStoreMetadataAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the remote store metadata action
+     */
     public HttpRemoteStoreMetadataAction(final HttpClient client, final RemoteStoreMetadataAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the remote store metadata request and notifies the listener with the response.
+     *
+     * @param request the remote store metadata request
+     * @param listener the listener to be notified with the remote store metadata response or a failure
+     */
     public void execute(final RemoteStoreMetadataRequest request, final ActionListener<RemoteStoreMetadataResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -52,6 +68,13 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a remote store metadata response from the given parser.
+     *
+     * @param parser the content parser
+     * @return the parsed remote store metadata response
+     * @throws IOException if parsing fails
+     */
     protected RemoteStoreMetadataResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -97,6 +120,13 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
                 failedShards, shardFailures);
     }
 
+    /**
+     * Parses the indices section of the response and collects shard metadata entries.
+     *
+     * @param parser the content parser positioned at the start of the indices object
+     * @param metadataList the list to which parsed shard metadata is added
+     * @throws IOException if parsing fails
+     */
     @SuppressWarnings("unchecked")
     protected void parseIndices(final XContentParser parser, final List<RemoteStoreShardMetadata> metadataList) throws IOException {
         // indices: { "index_name": { "shards": { "0": [ {shard metadata...} ] } } }
@@ -127,6 +157,15 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
         }
     }
 
+    /**
+     * Parses a single shard metadata object from the response.
+     *
+     * @param parser the content parser positioned inside a shard metadata object
+     * @param indexName the index name the shard belongs to
+     * @param shardId the shard identifier
+     * @return the parsed shard metadata
+     * @throws IOException if parsing fails
+     */
     @SuppressWarnings("unchecked")
     protected RemoteStoreShardMetadata parseShardMetadata(final XContentParser parser, final String indexName, final int shardId)
             throws IOException {
@@ -163,6 +202,13 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
                 latestTranslogMetadataFileName);
     }
 
+    /**
+     * Parses a metadata files object, mapping file names to their metadata.
+     *
+     * @param parser the content parser positioned inside a metadata files object
+     * @return a map of file name to metadata values
+     * @throws IOException if parsing fails
+     */
     protected Map<String, Map<String, Object>> parseMetadataFiles(final XContentParser parser) throws IOException {
         final Map<String, Map<String, Object>> files = new HashMap<>();
         XContentParser.Token token;
@@ -176,6 +222,12 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
         return files;
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -189,6 +241,12 @@ public class HttpRemoteStoreMetadataAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds a curl request for the remote store metadata request.
+     *
+     * @param request the remote store metadata request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RemoteStoreMetadataRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_remotestore/metadata");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRemoteStoreStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRemoteStoreStatsAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the remote store stats API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRemoteStoreStatsAction extends HttpAction {
 
+    /** The remote store stats action. */
     protected RemoteStoreStatsAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the remote store stats action
+     */
     public HttpRemoteStoreStatsAction(final HttpClient client, final RemoteStoreStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the remote store stats request and notifies the listener with the response.
+     *
+     * @param request the remote store stats request
+     * @param listener the listener to be notified with the remote store stats response or a failure
+     */
     public void execute(final RemoteStoreStatsRequest request, final ActionListener<RemoteStoreStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -51,6 +67,14 @@ public class HttpRemoteStoreStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a remote store stats response from the given parser. Shard counts are extracted while
+     * per-index stats are skipped, so the returned response contains an empty stats array.
+     *
+     * @param parser the content parser
+     * @return the parsed remote store stats response
+     * @throws IOException if parsing fails
+     */
     protected RemoteStoreStatsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -96,6 +120,12 @@ public class HttpRemoteStoreStatsAction extends HttpAction {
         return new RemoteStoreStatsResponse(new RemoteStoreStats[0], totalShards, successfulShards, failedShards, shardFailures);
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -109,6 +139,12 @@ public class HttpRemoteStoreStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds a curl request for the remote store stats request.
+     *
+     * @param request the remote store stats request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RemoteStoreStatsRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_remotestore/stats");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRestoreSnapshotAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRestoreSnapshotAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the restore snapshot API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRestoreSnapshotAction extends HttpAction {
 
+    /** The restore snapshot action. */
     protected final RestoreSnapshotAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the restore snapshot action
+     */
     public HttpRestoreSnapshotAction(final HttpClient client, final RestoreSnapshotAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the restore snapshot request and notifies the listener with the response.
+     *
+     * @param request the restore snapshot request
+     * @param listener the listener to be notified with the restore snapshot response or a failure
+     */
     public void execute(final RestoreSnapshotRequest request, final ActionListener<RestoreSnapshotResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -58,6 +74,12 @@ public class HttpRestoreSnapshotAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds a curl request for the restore snapshot request.
+     *
+     * @param request the restore snapshot request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RestoreSnapshotRequest request) {
         // RestRestoreSnapshotAction
         final StringBuilder pathBuf = new StringBuilder(100).append("/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpResumeIngestionAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpResumeIngestionAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the resume ingestion API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpResumeIngestionAction extends HttpAction {
 
+    /** The resume ingestion action. */
     protected final ResumeIngestionAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the resume ingestion action
+     */
     public HttpResumeIngestionAction(final HttpClient client, final ResumeIngestionAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the resume ingestion request and notifies the listener with the response.
+     *
+     * @param request the resume ingestion request
+     * @param listener the listener to be notified with the resume ingestion response or a failure
+     */
     public void execute(final ResumeIngestionRequest request, final ActionListener<ResumeIngestionResponse> listener) {
         String body = null;
         if (request.getResetSettings().length > 0) {
@@ -75,6 +91,13 @@ public class HttpResumeIngestionAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a resume ingestion response from the given parser.
+     *
+     * @param parser the content parser
+     * @return the parsed resume ingestion response
+     * @throws IOException if parsing fails
+     */
     protected ResumeIngestionResponse fromXContent(final XContentParser parser) throws IOException {
         boolean acknowledged = false;
         boolean shardsAcknowledged = false;
@@ -101,6 +124,12 @@ public class HttpResumeIngestionAction extends HttpAction {
         return new ResumeIngestionResponse(acknowledged, shardsAcknowledged, new IngestionStateShardFailure[0], "");
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -114,6 +143,12 @@ public class HttpResumeIngestionAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds a curl request for the resume ingestion request.
+     *
+     * @param request the resume ingestion request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final ResumeIngestionRequest request) {
         // RestResumeIngestionAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/ingestion/_resume", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRolloverAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRolloverAction.java
@@ -40,15 +40,31 @@ import org.opensearch.core.xcontent.ToXContent.Params;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the index rollover API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpRolloverAction extends HttpAction {
 
+    /** The rollover action. */
     protected final RolloverAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the rollover action
+     */
     public HttpRolloverAction(final HttpClient client, final RolloverAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the rollover request and notifies the listener with the response.
+     *
+     * @param request the rollover request
+     * @param listener the listener to be notified with the rollover response or a failure
+     */
     public void execute(final RolloverRequest request, final ActionListener<RolloverResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = toXContent(request, JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -67,6 +83,12 @@ public class HttpRolloverAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds a curl request for the rollover request.
+     *
+     * @param request the rollover request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final RolloverRequest request) {
         // RestRolloverIndexAction
         final CurlRequest curlRequest = client.getCurlRequest(POST,
@@ -90,6 +112,15 @@ public class HttpRolloverAction extends HttpAction {
 
     private static final ParseField CONDITIONS = new ParseField("conditions");
 
+    /**
+     * Serializes the rollover request, including its create index request and conditions, to XContent.
+     *
+     * @param request the rollover request
+     * @param builder the content builder to write to
+     * @param params the serialization parameters
+     * @return the content builder
+     * @throws IOException if serialization fails
+     */
     protected XContentBuilder toXContent(final RolloverRequest request, final XContentBuilder builder, final Params params)
             throws IOException {
         builder.startObject();
@@ -107,6 +138,15 @@ public class HttpRolloverAction extends HttpAction {
         return builder;
     }
 
+    /**
+     * Serializes the settings, mappings, and aliases of the create index request to XContent.
+     *
+     * @param createIndexRequest the create index request
+     * @param builder the content builder to write to
+     * @param params the serialization parameters
+     * @return the content builder
+     * @throws IOException if serialization fails
+     */
     protected XContentBuilder innerToXContent(final CreateIndexRequest createIndexRequest, final XContentBuilder builder,
             final Params params) throws IOException {
         builder.startObject(CreateIndexRequest.SETTINGS.getPreferredName());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpScaleIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpScaleIndexAction.java
@@ -26,15 +26,32 @@ import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the scale index (search-only) API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpScaleIndexAction extends HttpAction {
 
+    /** The scale index action. */
     protected final ScaleIndexAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the scale index action
+     */
     public HttpScaleIndexAction(final HttpClient client, final ScaleIndexAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the scale index request and notifies the listener with the response. The request
+     * fields are accessed via reflection because ScaleIndexRequest is package-private in OpenSearch.
+     *
+     * @param request the scale index request
+     * @param listener the listener to be notified with the acknowledged response or a failure
+     */
     public void execute(final ActionRequest request, final ActionListener<AcknowledgedResponse> listener) {
         // ScaleIndexRequest is package-private in OpenSearch, so reflection is the only way
         // to access getIndex() and isScaleDown() from outside the package.

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
+/**
+ * Handles the search API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpSearchAction extends HttpAction {
 
+    /** The search action. */
     protected final SearchAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the search action
+     */
     public HttpSearchAction(final HttpClient client, final SearchAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the search request and notifies the listener with the response.
+     *
+     * @param request the search request
+     * @param listener the listener to be notified with the search response or a failure
+     */
     public void execute(final SearchRequest request, final ActionListener<SearchResponse> listener) {
         getCurlRequest(request).body(getQuerySource(request)).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -55,6 +71,12 @@ public class HttpSearchAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Converts the search source of the request to a JSON string.
+     *
+     * @param request the search request
+     * @return the JSON representation of the search source, or null if the request has no source
+     */
     protected String getQuerySource(final SearchRequest request) {
         final SearchSourceBuilder source = request.source();
         if (source != null) {
@@ -67,6 +89,12 @@ public class HttpSearchAction extends HttpAction {
         return null;
     }
 
+    /**
+     * Builds a curl request for the search request.
+     *
+     * @param request the search request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final SearchRequest request) {
         // RestSearchAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_search", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSearchScrollAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSearchScrollAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the search scroll API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpSearchScrollAction extends HttpAction {
 
+    /** The search scroll action. */
     protected final SearchScrollAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the search scroll action
+     */
     public HttpSearchScrollAction(final HttpClient client, final SearchScrollAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the search scroll request and notifies the listener with the response.
+     *
+     * @param request the search scroll request
+     * @param listener the listener to be notified with the search response or a failure
+     */
     public void execute(final SearchScrollRequest request, final ActionListener<SearchResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -57,6 +73,12 @@ public class HttpSearchScrollAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds a curl request for the search scroll request.
+     *
+     * @param request the search scroll request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final SearchScrollRequest request) {
         // RestSearchScrollAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_search/scroll");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSearchViewAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSearchViewAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
+/**
+ * Handles the search view API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpSearchViewAction extends HttpAction {
 
+    /** The search view action. */
     protected final SearchViewAction action;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param client the HTTP client
+     * @param action the search view action
+     */
     public HttpSearchViewAction(final HttpClient client, final SearchViewAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the search view request and notifies the listener with the response.
+     *
+     * @param request the search view request
+     * @param listener the listener to be notified with the search response or a failure
+     */
     public void execute(final SearchViewAction.Request request, final ActionListener<SearchResponse> listener) {
         getCurlRequest(request).body(getQuerySource(request)).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -55,6 +71,12 @@ public class HttpSearchViewAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Converts the search source of the request to a JSON string.
+     *
+     * @param request the search view request
+     * @return the JSON representation of the search source, or null if the request has no source
+     */
     protected String getQuerySource(final SearchViewAction.Request request) {
         final SearchSourceBuilder source = request.source();
         if (source != null) {
@@ -67,6 +89,12 @@ public class HttpSearchViewAction extends HttpAction {
         return null;
     }
 
+    /**
+     * Builds a curl request for the search view request.
+     *
+     * @param request the search view request
+     * @return the curl request
+     */
     protected CurlRequest getCurlRequest(final SearchViewAction.Request request) {
         // RestViewAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/views/" + UrlUtils.encode(request.getView()) + "/_search");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSegmentReplicationStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSegmentReplicationStatsAction.java
@@ -33,15 +33,32 @@ import org.opensearch.core.action.support.DefaultShardOperationFailedException;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.SegmentReplicationPerGroupStats;
 
+/**
+ * Handles the segment replication stats API over HTTP for OpenSearch/Elasticsearch.
+ * Uses the CAT segment replication endpoint to retrieve replication statistics.
+ */
 public class HttpSegmentReplicationStatsAction extends HttpAction {
 
+    /** The segment replication stats action definition. */
     protected SegmentReplicationStatsAction action;
 
+    /**
+     * Creates a new HTTP segment replication stats action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the segment replication stats action definition
+     */
     public HttpSegmentReplicationStatsAction(final HttpClient client, final SegmentReplicationStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the segment replication stats request and notifies the listener with the response.
+     *
+     * @param request the segment replication stats request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final SegmentReplicationStatsRequest request, final ActionListener<SegmentReplicationStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -53,6 +70,15 @@ public class HttpSegmentReplicationStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses the CAT segment replication response. Since the CAT API response format does not
+     * match the expected {@link SegmentReplicationStatsResponse} structure, the content is
+     * consumed and an empty response is returned.
+     *
+     * @param parser the parser positioned at the response content
+     * @return an empty segment replication stats response
+     * @throws IOException if parsing fails
+     */
     protected SegmentReplicationStatsResponse fromXContent(final XContentParser parser) throws IOException {
         // CAT API returns an array of objects, not a standard response format
         // We need to handle this differently
@@ -79,6 +105,12 @@ public class HttpSegmentReplicationStatsAction extends HttpAction {
                 replicationStats, shardFailures);
     }
 
+    /**
+     * Consumes the current object from the parser, including all nested objects and arrays.
+     *
+     * @param parser the parser positioned inside the object to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -92,6 +124,12 @@ public class HttpSegmentReplicationStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes the current array from the parser, including all nested objects and arrays.
+     *
+     * @param parser the parser positioned inside the array to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeArray(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -105,6 +143,12 @@ public class HttpSegmentReplicationStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the segment replication stats API.
+     *
+     * @param request the segment replication stats request
+     * @return the curl request for the CAT segment replication endpoint
+     */
     protected CurlRequest getCurlRequest(final SegmentReplicationStatsRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_cat/segment_replication");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSimulatePipelineAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSimulatePipelineAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the simulate pipeline API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpSimulatePipelineAction extends HttpAction {
 
+    /** The simulate pipeline action definition. */
     protected final SimulatePipelineAction action;
 
+    /**
+     * Creates a new HTTP simulate pipeline action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the simulate pipeline action definition
+     */
     public HttpSimulatePipelineAction(final HttpClient client, final SimulatePipelineAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the simulate pipeline request and notifies the listener with the response.
+     *
+     * @param request the simulate pipeline request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final SimulatePipelineRequest request, final ActionListener<SimulatePipelineResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -58,6 +74,12 @@ public class HttpSimulatePipelineAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the simulate pipeline API.
+     *
+     * @param request the simulate pipeline request
+     * @return the curl request for the simulate pipeline endpoint
+     */
     protected CurlRequest getCurlRequest(final SimulatePipelineRequest request) {
         // RestSimulatePipelineAction
         final String path = request.getId() != null ? "/_ingest/pipeline/" + UrlUtils.encode(request.getId()) + "/_simulate"

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSnapshotsStatusAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSnapshotsStatusAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.admin.cluster.snapshots.status.SnapshotsStatusRespo
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the snapshots status API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpSnapshotsStatusAction extends HttpAction {
 
+    /** The snapshots status action definition. */
     protected final SnapshotsStatusAction action;
 
+    /**
+     * Creates a new HTTP snapshots status action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the snapshots status action definition
+     */
     public HttpSnapshotsStatusAction(final HttpClient client, final SnapshotsStatusAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the snapshots status request and notifies the listener with the response.
+     *
+     * @param request the snapshots status request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final SnapshotsStatusRequest request, final ActionListener<SnapshotsStatusResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpSnapshotsStatusAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the snapshots status API.
+     *
+     * @param request the snapshots status request
+     * @return the curl request for the snapshot status endpoint
+     */
     protected CurlRequest getCurlRequest(final SnapshotsStatusRequest request) {
         // RestSnapshotsStatusAction
         final StringBuilder pathBuf = new StringBuilder(100).append("/_snapshot");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpTermVectorsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpTermVectorsAction.java
@@ -31,15 +31,31 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the term vectors API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpTermVectorsAction extends HttpAction {
 
+    /** The term vectors action definition. */
     protected final TermVectorsAction action;
 
+    /**
+     * Creates a new HTTP term vectors action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the term vectors action definition
+     */
     public HttpTermVectorsAction(final HttpClient client, final TermVectorsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the term vectors request and notifies the listener with the response.
+     *
+     * @param request the term vectors request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final TermVectorsRequest request, final ActionListener<TermVectorsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -51,6 +67,14 @@ public class HttpTermVectorsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a term vectors response, extracting the index, document id, found flag, and took time.
+     * Nested term vector details are consumed but not parsed.
+     *
+     * @param parser the parser positioned at the response content
+     * @return the parsed term vectors response
+     * @throws IOException if parsing fails
+     */
     protected TermVectorsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         String index = "";
@@ -95,6 +119,12 @@ public class HttpTermVectorsAction extends HttpAction {
         return response;
     }
 
+    /**
+     * Consumes the current object or array from the parser, including all nested structures.
+     *
+     * @param parser the parser positioned inside the structure to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -108,6 +138,12 @@ public class HttpTermVectorsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the term vectors API.
+     *
+     * @param request the term vectors request
+     * @return the curl request for the term vectors endpoint
+     */
     protected CurlRequest getCurlRequest(final TermVectorsRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append('/').append(UrlUtils.encode(request.index())).append("/_termvectors");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
@@ -38,15 +38,31 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
 
+/**
+ * Handles the document update API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpUpdateAction extends HttpAction {
 
+    /** The update action definition. */
     protected final UpdateAction action;
 
+    /**
+     * Creates a new HTTP update action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the update action definition
+     */
     public HttpUpdateAction(final HttpClient client, final UpdateAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the update request and notifies the listener with the response.
+     *
+     * @param request the update request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final UpdateRequest request, final ActionListener<UpdateResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -65,6 +81,13 @@ public class HttpUpdateAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses an update response from the given parser.
+     *
+     * @param parser the parser positioned at the response content
+     * @return the parsed update response
+     * @throws IOException if parsing fails
+     */
     // UpdateResponse.fromXContent(parser)
     protected UpdateResponse fromXContent(final XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
@@ -76,6 +99,12 @@ public class HttpUpdateAction extends HttpAction {
         return context.build();
     }
 
+    /**
+     * Builds the curl request for the update API.
+     *
+     * @param request the update request
+     * @return the curl request for the update endpoint
+     */
     protected CurlRequest getCurlRequest(final UpdateRequest request) {
         // RestUpdateAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_update/" + UrlUtils.encode(request.id()), request.index());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the update index settings API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpUpdateSettingsAction extends HttpAction {
 
+    /** The update settings action definition. */
     protected final UpdateSettingsAction action;
 
+    /**
+     * Creates a new HTTP update settings action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the update settings action definition
+     */
     public HttpUpdateSettingsAction(final HttpClient client, final UpdateSettingsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the update settings request and notifies the listener with the response.
+     *
+     * @param request the update settings request
+     * @param listener the listener notified with the acknowledged response or a failure
+     */
     public void execute(final UpdateSettingsRequest request, final ActionListener<AcknowledgedResponse> listener) {
         String source = null;
         try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
@@ -57,6 +73,12 @@ public class HttpUpdateSettingsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the update settings API.
+     *
+     * @param request the update settings request
+     * @return the curl request for the settings endpoint
+     */
     protected CurlRequest getCurlRequest(final UpdateSettingsRequest request) {
         // RestUpdateSettingsAction
         final CurlRequest curlRequest = client.getCurlRequest(PUT, "/_settings", request.indices());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateViewAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateViewAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the update view API over HTTP for OpenSearch.
+ */
 public class HttpUpdateViewAction extends HttpAction {
 
+    /** The update view action definition. */
     protected final UpdateViewAction action;
 
+    /**
+     * Creates a new HTTP update view action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the update view action definition
+     */
     public HttpUpdateViewAction(final HttpClient client, final UpdateViewAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the update view request and notifies the listener with the response.
+     *
+     * @param request the view request containing the view definition to update
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final CreateViewAction.Request request, final ActionListener<GetViewAction.Response> listener) {
         final String source = buildRequestBody(request);
         getCurlRequest(request).body(source).execute(response -> {
@@ -51,6 +67,12 @@ public class HttpUpdateViewAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the JSON request body containing the view description and targets.
+     *
+     * @param request the view request
+     * @return the JSON request body as a string
+     */
     protected String buildRequestBody(final CreateViewAction.Request request) {
         try (final XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
@@ -70,6 +92,12 @@ public class HttpUpdateViewAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the update view API.
+     *
+     * @param request the view request
+     * @return the curl request for the views endpoint
+     */
     protected CurlRequest getCurlRequest(final CreateViewAction.Request request) {
         // RestViewAction
         return client.getCurlRequest(PUT, "/views/" + UrlUtils.encode(request.getName()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeAction.java
@@ -27,15 +27,31 @@ import org.opensearch.action.admin.indices.upgrade.post.UpgradeResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the index upgrade API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpUpgradeAction extends HttpAction {
 
+    /** The upgrade action definition. */
     protected final UpgradeAction action;
 
+    /**
+     * Creates a new HTTP upgrade action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the upgrade action definition
+     */
     public HttpUpgradeAction(final HttpClient client, final UpgradeAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the upgrade request and notifies the listener with the response.
+     *
+     * @param request the upgrade request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final UpgradeRequest request, final ActionListener<UpgradeResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -47,6 +63,15 @@ public class HttpUpgradeAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses an upgrade response, extracting the shard counts from the {@code _shards} section.
+     * Since {@link UpgradeResponse} has package-private constructors, the response is
+     * reconstructed via the wire format.
+     *
+     * @param parser the parser positioned at the response content
+     * @return the parsed upgrade response
+     * @throws IOException if parsing fails
+     */
     protected UpgradeResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -99,6 +124,12 @@ public class HttpUpgradeAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes the current object from the parser, including all nested objects and arrays.
+     *
+     * @param parser the parser positioned inside the object to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -112,6 +143,12 @@ public class HttpUpgradeAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the upgrade API.
+     *
+     * @param request the upgrade request
+     * @return the curl request for the upgrade endpoint
+     */
     protected CurlRequest getCurlRequest(final UpgradeRequest request) {
         // RestUpgradeAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeStatusAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeStatusAction.java
@@ -27,15 +27,31 @@ import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the upgrade status API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpUpgradeStatusAction extends HttpAction {
 
+    /** The upgrade status action definition. */
     protected final UpgradeStatusAction action;
 
+    /**
+     * Creates a new HTTP upgrade status action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the upgrade status action definition
+     */
     public HttpUpgradeStatusAction(final HttpClient client, final UpgradeStatusAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the upgrade status request and notifies the listener with the response.
+     *
+     * @param request the upgrade status request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final UpgradeStatusRequest request, final ActionListener<UpgradeStatusResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -47,6 +63,15 @@ public class HttpUpgradeStatusAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses an upgrade status response, extracting the shard counts from the {@code _shards} section.
+     * Since {@link UpgradeStatusResponse} has package-private constructors, the response is
+     * reconstructed via the wire format.
+     *
+     * @param parser the parser positioned at the response content
+     * @return the parsed upgrade status response
+     * @throws IOException if parsing fails
+     */
     protected UpgradeStatusResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         int totalShards = 0;
@@ -99,6 +124,12 @@ public class HttpUpgradeStatusAction extends HttpAction {
         }
     }
 
+    /**
+     * Consumes the current object from the parser, including all nested objects and arrays.
+     *
+     * @param parser the parser positioned inside the object to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -112,6 +143,12 @@ public class HttpUpgradeStatusAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the upgrade status API.
+     *
+     * @param request the upgrade status request
+     * @return the curl request for the upgrade status endpoint
+     */
     protected CurlRequest getCurlRequest(final UpgradeStatusRequest request) {
         // RestUpgradeStatusAction
         final StringBuilder buf = new StringBuilder();

--- a/src/main/java/org/codelibs/fesen/client/action/HttpValidateQueryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpValidateQueryAction.java
@@ -29,15 +29,31 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the validate query API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpValidateQueryAction extends HttpAction {
 
+    /** The validate query action definition. */
     protected final ValidateQueryAction action;
 
+    /**
+     * Creates a new HTTP validate query action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the validate query action definition
+     */
     public HttpValidateQueryAction(final HttpClient client, final ValidateQueryAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the validate query request and notifies the listener with the response.
+     *
+     * @param request the validate query request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final ValidateQueryRequest request, final ActionListener<ValidateQueryResponse> listener) {
         String source = null;
         try (final XContentBuilder builder =
@@ -57,6 +73,12 @@ public class HttpValidateQueryAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the validate query API.
+     *
+     * @param request the validate query request
+     * @return the curl request for the validate query endpoint
+     */
     protected CurlRequest getCurlRequest(final ValidateQueryRequest request) {
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_validate/query", request.indices());
         curlRequest.param("explain", Boolean.toString(request.explain()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpVerifyRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpVerifyRepositoryAction.java
@@ -24,15 +24,31 @@ import org.opensearch.action.admin.cluster.repositories.verify.VerifyRepositoryR
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 
+/**
+ * Handles the verify repository API over HTTP for OpenSearch/Elasticsearch.
+ */
 public class HttpVerifyRepositoryAction extends HttpAction {
 
+    /** The verify repository action definition. */
     protected final VerifyRepositoryAction action;
 
+    /**
+     * Creates a new HTTP verify repository action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the verify repository action definition
+     */
     public HttpVerifyRepositoryAction(final HttpClient client, final VerifyRepositoryAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the verify repository request and notifies the listener with the response.
+     *
+     * @param request the verify repository request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final VerifyRepositoryRequest request, final ActionListener<VerifyRepositoryResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -44,6 +60,12 @@ public class HttpVerifyRepositoryAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Builds the curl request for the verify repository API.
+     *
+     * @param request the verify repository request
+     * @return the curl request for the repository verify endpoint
+     */
     protected CurlRequest getCurlRequest(final VerifyRepositoryRequest request) {
         // RestVerifyRepositoryAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_snapshot/" + UrlUtils.encode(request.name()) + "/_verify");

--- a/src/main/java/org/codelibs/fesen/client/action/HttpWlmStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpWlmStatsAction.java
@@ -30,15 +30,31 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.wlm.stats.WlmStats;
 
+/**
+ * Handles the workload management (WLM) stats API over HTTP for OpenSearch.
+ */
 public class HttpWlmStatsAction extends HttpAction {
 
+    /** The WLM stats action definition. */
     protected WlmStatsAction action;
 
+    /**
+     * Creates a new HTTP WLM stats action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the WLM stats action definition
+     */
     public HttpWlmStatsAction(final HttpClient client, final WlmStatsAction action) {
         super(client);
         this.action = action;
     }
 
+    /**
+     * Executes the WLM stats request and notifies the listener with the response.
+     *
+     * @param request the WLM stats request
+     * @param listener the listener notified with the response or a failure
+     */
     public void execute(final WlmStatsRequest request, final ActionListener<WlmStatsResponse> listener) {
         getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
@@ -50,6 +66,14 @@ public class HttpWlmStatsAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
+    /**
+     * Parses a WLM stats response, extracting the cluster name. Per-node WLM stats are
+     * consumed but not parsed, so the returned response contains an empty node list.
+     *
+     * @param parser the parser positioned at the response content
+     * @return the parsed WLM stats response
+     * @throws IOException if parsing fails
+     */
     protected WlmStatsResponse fromXContent(final XContentParser parser) throws IOException {
         String fieldName = null;
         ClusterName clusterName = ClusterName.DEFAULT;
@@ -86,6 +110,12 @@ public class HttpWlmStatsAction extends HttpAction {
         return new WlmStatsResponse(clusterName, nodes, Collections.emptyList());
     }
 
+    /**
+     * Consumes the current object from the parser, including all nested objects and arrays.
+     *
+     * @param parser the parser positioned inside the object to consume
+     * @throws IOException if parsing fails
+     */
     protected void consumeObject(final XContentParser parser) throws IOException {
         XContentParser.Token token;
         int depth = 1;
@@ -99,6 +129,12 @@ public class HttpWlmStatsAction extends HttpAction {
         }
     }
 
+    /**
+     * Builds the curl request for the WLM stats API.
+     *
+     * @param request the WLM stats request
+     * @return the curl request for the WLM stats endpoint
+     */
     protected CurlRequest getCurlRequest(final WlmStatsRequest request) {
         final StringBuilder buf = new StringBuilder();
         buf.append("/_wlm");

--- a/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequest.java
+++ b/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequest.java
@@ -45,10 +45,19 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.tasks.Task;
 
+/**
+ * A {@link CreateIndexRequest} wrapper for HTTP-based clients that adjusts how the
+ * settings and mappings source is prepared, ensuring mappings are not nested under a type name.
+ */
 public class HttpCreateIndexRequest extends CreateIndexRequest {
 
     private final CreateIndexRequest request;
 
+    /**
+     * Creates a new HTTP create index request wrapping the given request.
+     *
+     * @param request the create index request to delegate to
+     */
     public HttpCreateIndexRequest(final CreateIndexRequest request) {
         this.request = request;
     }
@@ -120,6 +129,14 @@ public class HttpCreateIndexRequest extends CreateIndexRequest {
         return this;
     }
 
+    /**
+     * Wraps the mapping definition under the single mapping type name, rejecting sources
+     * whose mapping definition is already nested under a type.
+     *
+     * @param source the source map containing settings and mappings
+     * @return the source map with the mappings wrapped under the single mapping type
+     * @throws IllegalArgumentException if the mapping definition is nested under a type
+     */
     // RestCreateIndexAction#prepareMappings
     public static Map<String, Object> prepareMappings(final Map<String, Object> source) {
         if (!source.containsKey("mappings") || !(source.get("mappings") instanceof Map)) {

--- a/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequrestBuilder.java
+++ b/src/main/java/org/codelibs/fesen/client/action/indices/create/HttpCreateIndexRequrestBuilder.java
@@ -26,14 +26,31 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.transport.client.OpenSearchClient;
 
+/**
+ * A {@link CreateIndexRequestBuilder} for HTTP-based clients that delegates source handling
+ * to {@link HttpCreateIndexRequest} so mappings are prepared for the HTTP API.
+ */
 public class HttpCreateIndexRequrestBuilder extends CreateIndexRequestBuilder {
     private final HttpCreateIndexRequest request;
 
+    /**
+     * Creates a new HTTP create index request builder.
+     *
+     * @param client the client used to execute the request
+     * @param action the create index action definition
+     */
     public HttpCreateIndexRequrestBuilder(final OpenSearchClient client, final CreateIndexAction action) {
         super(client, action);
         request = new HttpCreateIndexRequest(request());
     }
 
+    /**
+     * Creates a new HTTP create index request builder for the given index.
+     *
+     * @param client the client used to execute the request
+     * @param action the create index action definition
+     * @param index the name of the index to create
+     */
     public HttpCreateIndexRequrestBuilder(final OpenSearchClient client, final CreateIndexAction action, final String index) {
         super(client, action, index);
         request = new HttpCreateIndexRequest(request());

--- a/src/main/java/org/codelibs/fesen/client/curl/FesenRequest.java
+++ b/src/main/java/org/codelibs/fesen/client/curl/FesenRequest.java
@@ -28,16 +28,32 @@ import org.codelibs.fesen.client.node.NodeManager;
 import org.codelibs.fesen.client.node.NodeUnavailableException;
 import org.opensearch.index.IndexNotFoundException;
 
+/**
+ * A {@link CurlRequest} that targets a cluster of nodes managed by a {@link NodeManager}.
+ * The request is executed against an available node, and if the node fails with a
+ * recoverable error, the node is marked as unavailable and the request is retried on
+ * the next available node.
+ */
 public class FesenRequest extends CurlRequest {
 
     private static final Logger logger = LogManager.getLogger(FesenRequest.class);
 
+    /** The node manager that provides the nodes to send requests to. */
     protected final NodeManager nodeManager;
 
+    /** The request path appended to the node URL. */
     protected final String path;
 
+    /** The iterator over the nodes used for failover. */
     protected final NodeIterator nodeIter;
 
+    /**
+     * Creates a new request for the given path using nodes from the node manager.
+     *
+     * @param request the original request whose HTTP method is reused
+     * @param nodeManager the node manager that provides target nodes
+     * @param path the request path appended to the node URL
+     */
     public FesenRequest(final CurlRequest request, final NodeManager nodeManager, final String path) {
         super(request.method(), null);
         this.nodeManager = nodeManager;
@@ -50,6 +66,14 @@ public class FesenRequest extends CurlRequest {
         execute(actionListener, exceptionListener, null);
     }
 
+    /**
+     * Executes the request asynchronously against the next available node, retrying on
+     * other nodes when a recoverable failure occurs.
+     *
+     * @param actionListener the listener invoked with the response on success
+     * @param exceptionListener the listener invoked when no node can process the request
+     * @param previous the exception from the previous attempt, or {@code null} for the first attempt
+     */
     protected void execute(final Consumer<CurlResponse> actionListener, final Consumer<Exception> exceptionListener,
             final Exception previous) {
         getNode().ifPresentOrElse(node -> {
@@ -80,6 +104,14 @@ public class FesenRequest extends CurlRequest {
         return execute(null);
     }
 
+    /**
+     * Executes the request synchronously against the next available node, retrying on
+     * other nodes when a recoverable failure occurs.
+     *
+     * @param previous the exception from the previous attempt, or {@code null} for the first attempt
+     * @return the response from the first node that processed the request
+     * @throws NodeUnavailableException if all nodes are unavailable and there is no previous exception
+     */
     protected CurlResponse execute(final RuntimeException previous) {
         return getNode().map(node -> {
             url = node.getUrl(path);
@@ -104,6 +136,13 @@ public class FesenRequest extends CurlRequest {
         });
     }
 
+    /**
+     * Determines whether the given exception should trigger a failover to another node.
+     * Exceptions caused by {@link IndexNotFoundException} are not retried.
+     *
+     * @param e the exception to inspect
+     * @return {@code true} if the request should be retried on another node
+     */
     protected boolean isTargetException(final Exception e) {
         int count = 0;
         Throwable t = e;
@@ -117,6 +156,11 @@ public class FesenRequest extends CurlRequest {
         return true;
     }
 
+    /**
+     * Returns the next available node from the node iterator.
+     *
+     * @return an {@link Optional} containing the next available node, or empty if none is available
+     */
     protected Optional<Node> getNode() {
         while (nodeIter.hasNext()) {
             final Node node = nodeIter.next();

--- a/src/main/java/org/codelibs/fesen/client/io/stream/ByteArrayStreamOutput.java
+++ b/src/main/java/org/codelibs/fesen/client/io/stream/ByteArrayStreamOutput.java
@@ -23,9 +23,16 @@ import org.opensearch.core.common.io.stream.InputStreamStreamInput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
+/**
+ * A {@link StreamOutput} implementation backed by a {@link ByteArrayOutputStream}.
+ * The written content can be retrieved as a byte array or converted to a {@link StreamInput}.
+ */
 public class ByteArrayStreamOutput extends StreamOutput {
     private final ByteArrayOutputStream out;
 
+    /**
+     * Creates a new stream output backed by an empty byte array output stream.
+     */
     public ByteArrayStreamOutput() {
         this.out = new ByteArrayOutputStream();
     }
@@ -55,10 +62,20 @@ public class ByteArrayStreamOutput extends StreamOutput {
         out.reset();
     }
 
+    /**
+     * Returns a copy of the bytes written to this stream.
+     *
+     * @return the written content as a byte array
+     */
     public byte[] toByteArray() {
         return out.toByteArray();
     }
 
+    /**
+     * Creates a {@link StreamInput} that reads the bytes written to this stream.
+     *
+     * @return a stream input over the written content
+     */
     public StreamInput toStreamInput() {
         return new InputStreamStreamInput(new ByteArrayInputStream(toByteArray()));
     }

--- a/src/main/java/org/codelibs/fesen/client/node/Node.java
+++ b/src/main/java/org/codelibs/fesen/client/node/Node.java
@@ -17,24 +17,51 @@ package org.codelibs.fesen.client.node;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Represents a single node (host) in an OpenSearch/Elasticsearch cluster
+ * along with its availability state.
+ */
 public class Node {
 
+    /** The base URL of the node (e.g. {@code http://localhost:9200}). */
     protected String host;
 
+    /** Whether this node is currently available. */
     protected AtomicBoolean available = new AtomicBoolean(true);
 
+    /**
+     * Creates a new node for the given host.
+     *
+     * @param host the base URL of the node
+     */
     public Node(final String host) {
         this.host = host;
     }
 
+    /**
+     * Builds a full URL by appending the given path to this node's host.
+     *
+     * @param path the request path
+     * @return the full URL for the request
+     */
     public String getUrl(final String path) {
         return host + path;
     }
 
+    /**
+     * Returns whether this node is currently available.
+     *
+     * @return {@code true} if the node is available
+     */
     public boolean isAvailable() {
         return available.get();
     }
 
+    /**
+     * Sets the availability state of this node.
+     *
+     * @param available {@code true} to mark the node as available
+     */
     public void setAvailable(final boolean available) {
         this.available.set(available);
     }

--- a/src/main/java/org/codelibs/fesen/client/node/NodeIterator.java
+++ b/src/main/java/org/codelibs/fesen/client/node/NodeIterator.java
@@ -19,16 +19,29 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * An iterator over a fixed array of nodes that starts from a round-robin
+ * position and visits each node exactly once, wrapping around the array.
+ */
 public class NodeIterator implements Iterator<Node> {
 
+    /** A shared counter used to determine the round-robin start position. */
     protected static AtomicInteger positionCounter = new AtomicInteger();
 
+    /** The nodes to iterate over. */
     protected final Node[] nodes;
 
+    /** The current position in the node array. */
     protected int position;
 
+    /** The number of nodes returned so far. */
     protected int count = 0;
 
+    /**
+     * Creates a new iterator over the given nodes, starting at a round-robin position.
+     *
+     * @param nodes the nodes to iterate over
+     */
     public NodeIterator(final Node[] nodes) {
         this.nodes = nodes;
         this.position = positionCounter.incrementAndGet() % nodes.length;

--- a/src/main/java/org/codelibs/fesen/client/node/NodeManager.java
+++ b/src/main/java/org/codelibs/fesen/client/node/NodeManager.java
@@ -37,21 +37,38 @@ import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.HttpClient.ContentType;
 import org.codelibs.fesen.client.util.MaxMapCountCheck;
 
+/**
+ * Manages a set of cluster nodes, tracking their availability and periodically
+ * checking unavailable nodes so they can be brought back into rotation.
+ */
 public class NodeManager {
     private static final Logger logger = LogManager.getLogger(NodeManager.class);
 
     private static final AtomicInteger nextSerialNumber = new AtomicInteger();
 
+    /** The managed nodes. */
     protected final Node[] nodes;
 
+    /** A factory that creates a health-check request for a node. */
     protected Function<Node, CurlRequest> requestCreator;
 
+    /** The interval in milliseconds between node availability checks. */
     protected long heartbeatInterval = 10 * 1000L; // 10sec;
 
+    /** The timer used to schedule node availability checks. */
     protected Timer timer;
 
+    /** Whether this node manager is running. */
     protected AtomicBoolean isRunning = new AtomicBoolean(true);
 
+    /**
+     * Creates a node manager for the given hosts using the given request creator
+     * for node availability checks. If the request creator is not {@code null},
+     * a background checker is scheduled.
+     *
+     * @param hosts the base URLs of the nodes to manage
+     * @param requestCreator a factory that creates a health-check request for a node, or {@code null} to disable checks
+     */
     public NodeManager(final String[] hosts, final Function<Node, CurlRequest> requestCreator) {
         this(hosts);
 
@@ -62,6 +79,13 @@ public class NodeManager {
         }
     }
 
+    /**
+     * Creates a node manager for the given hosts that checks node availability
+     * by sending a GET request to the root path via the given HTTP client.
+     *
+     * @param hosts the base URLs of the nodes to manage
+     * @param client the HTTP client used for node availability checks
+     */
     public NodeManager(final String[] hosts, final HttpClient client) {
         this(hosts, node -> client.getPlainCurlRequest(s -> Curl.get(node.getUrl(s)), ContentType.JSON, "/"));
     }
@@ -73,6 +97,9 @@ public class NodeManager {
         }
     }
 
+    /**
+     * Schedules the next node availability check if this manager is still running.
+     */
     protected void scheduleNodeChecker() {
         if (isRunning.get()) {
             if (logger.isDebugEnabled()) {
@@ -82,6 +109,9 @@ public class NodeManager {
         }
     }
 
+    /**
+     * Stops this node manager and cancels the scheduled node availability checks.
+     */
     public void close() {
         if (logger.isDebugEnabled()) {
             logger.debug("{} closing node manager.", this.toNodeString());
@@ -92,6 +122,12 @@ public class NodeManager {
         }
     }
 
+    /**
+     * Returns an iterator over the managed nodes. If no node is currently
+     * available, all nodes are reset to available before the iterator is created.
+     *
+     * @return an iterator over the managed nodes
+     */
     public NodeIterator getNodeIterator() {
         if (!hasAliveNode()) {
             if (logger.isDebugEnabled()) {
@@ -105,14 +141,29 @@ public class NodeManager {
         return new NodeIterator(nodes);
     }
 
+    /**
+     * Returns a comma-separated string describing the managed nodes and their states.
+     *
+     * @return a string representation of the managed nodes
+     */
     public String toNodeString() {
         return Arrays.stream(nodes).map(Node::toString).collect(Collectors.joining(","));
     }
 
+    /**
+     * Sets the interval between node availability checks.
+     *
+     * @param interval the interval in milliseconds
+     */
     public void setHeartbeatInterval(final long interval) {
         this.heartbeatInterval = interval;
     }
 
+    /**
+     * Returns whether at least one managed node is available.
+     *
+     * @return {@code true} if any node is available
+     */
     protected boolean hasAliveNode() {
         for (final Node node : nodes) {
             if (node.isAvailable()) {
@@ -122,6 +173,12 @@ public class NodeManager {
         return false;
     }
 
+    /**
+     * Unwraps nested {@link CurlException}s and returns the underlying cause.
+     *
+     * @param t the throwable to unwrap
+     * @return the root cause, or the given throwable if it is not a {@link CurlException}
+     */
     protected Throwable getCause(final Throwable t) {
         if (!(t instanceof CurlException)) {
             return t;

--- a/src/main/java/org/codelibs/fesen/client/node/NodeUnavailableException.java
+++ b/src/main/java/org/codelibs/fesen/client/node/NodeUnavailableException.java
@@ -17,10 +17,18 @@ package org.codelibs.fesen.client.node;
 
 import org.opensearch.OpenSearchException;
 
+/**
+ * An exception thrown when no node in the cluster is available to process a request.
+ */
 public class NodeUnavailableException extends OpenSearchException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new exception with the given message.
+     *
+     * @param msg the detail message
+     */
     public NodeUnavailableException(final String msg) {
         super(msg);
     }

--- a/src/main/java/org/codelibs/fesen/client/util/MaxMapCountCheck.java
+++ b/src/main/java/org/codelibs/fesen/client/util/MaxMapCountCheck.java
@@ -25,16 +25,35 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.common.io.PathUtils;
 
+/**
+ * Checks whether the operating system setting {@code vm.max_map_count} meets
+ * the minimum value required to run OpenSearch/Elasticsearch.
+ */
 public class MaxMapCountCheck {
+    /** The minimum required value of {@code vm.max_map_count}. */
     public static final long LIMIT = 1 << 18;
 
     private static final Logger logger = LogManager.getLogger(MaxMapCountCheck.class);
 
+    private MaxMapCountCheck() {
+        // utility class
+    }
+
+    /**
+     * Validates that {@code vm.max_map_count} meets the required minimum value.
+     *
+     * @return {@code true} if the value meets {@link #LIMIT} or cannot be determined
+     */
     public static boolean validate() {
         final long maxMapCount = getMaxMapCount();
         return maxMapCount == -1 || maxMapCount >= LIMIT;
     }
 
+    /**
+     * Reads the value of {@code vm.max_map_count} from {@code /proc/sys/vm/max_map_count}.
+     *
+     * @return the value, or {@code -1} if it cannot be read or parsed
+     */
     protected static long getMaxMapCount() {
         final Path path = PathUtils.get("/proc/sys/vm/max_map_count");
         try (BufferedReader bufferedReader = Files.newBufferedReader(path)) {

--- a/src/main/java/org/codelibs/fesen/client/util/UrlUtils.java
+++ b/src/main/java/org/codelibs/fesen/client/util/UrlUtils.java
@@ -23,6 +23,9 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Utility methods for URL-encoding values used in request paths and parameters.
+ */
 public final class UrlUtils {
 
     private static final Logger logger = LogManager.getLogger(UrlUtils.class);
@@ -31,6 +34,13 @@ public final class UrlUtils {
         // nothing
     }
 
+    /**
+     * URL-encodes each element and joins them with the given delimiter.
+     *
+     * @param delimiter the delimiter placed between the encoded elements
+     * @param elements the elements to encode and join
+     * @return the joined string, or {@code null} if {@code elements} is {@code null}
+     */
     public static String joinAndEncode(final CharSequence delimiter, final CharSequence... elements) {
         if (elements == null) {
             return null;
@@ -38,6 +48,12 @@ public final class UrlUtils {
         return Arrays.stream(elements).map(UrlUtils::encode).collect(Collectors.joining(delimiter));
     }
 
+    /**
+     * URL-encodes the given value using UTF-8.
+     *
+     * @param element the value to encode
+     * @return the encoded value, or {@code null} if {@code element} is {@code null}
+     */
     public static String encode(final CharSequence element) {
         if (element == null) {
             return null;


### PR DESCRIPTION
## Summary
Adds comprehensive Javadoc documentation across the entire codebase to improve public API documentation and IDE support.

## Changes Made
- Added class-level and method-level Javadoc to all 95+ `HttpAction` implementations in `action/`
- Added Javadoc to core client classes: `HttpClient`, `HttpAbstractClient`, `HttpAdminClient`, `HttpIndicesAdminClient`
- Documented `EngineInfo` class, constructor, all getters, `getType()`, and the `EngineType` enum constants
- Added Javadoc to `FesenRequest`, `ByteArrayStreamOutput`, node management types (`Node`, `NodeIterator`, `NodeManager`, `NodeUnavailableException`), and utilities (`MaxMapCountCheck`, `UrlUtils`)
- Expanded `EngineType` enum from single-line to multi-constant format with individual constant documentation

## Testing
No functional changes — documentation only. Existing tests cover behavior.

## Breaking Changes
None.

## Additional Notes
This is a pure documentation pass to make the library easier to use from IDEs and to help consumers understand the public API without reading source code.