### PR TITLE
build(pom): move GPG signing to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,23 +148,9 @@
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>3.1.1</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.8</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-						<configuration>
-							<bestPractices>true</bestPractices>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<releaseProfiles>release</releaseProfiles>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
@@ -177,6 +163,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>


### PR DESCRIPTION
## Summary
Stop requiring GPG signing for local builds by moving the maven-gpg-plugin into a \`release\` profile, matching the convention used by other CodeLibs repositories (corelib, curl4j, jcifs, etc.).

## Changes Made
- Moved \`maven-gpg-plugin\` from the main \`<build>\` section into a new \`release\` profile (same plugin definition: \`sign\` bound to the \`verify\` phase with \`bestPractices=true\`).
- Added \`<releaseProfiles>release</releaseProfiles>\` to \`maven-release-plugin\` so the profile is activated automatically during \`release:perform\`. This is needed because this repository releases via maven-release-plugin, unlike the other repos where \`-P release\` is passed manually.

## Testing
- \`mvn clean install -DskipTests\` (no gpg flags): succeeds without invoking GPG.
- \`mvn verify -P release\`: confirms \`gpg:sign (sign-artifacts)\` is bound and executes under the profile.

## Breaking Changes
- None for consumers. Release operators: signing now only runs under the \`release\` profile, which \`release:perform\` activates via \`releaseProfiles\`; manual deploys must pass \`-P release\`.

## Additional Notes
- Previously, plain \`mvn install\` failed in non-interactive environments with \`gpg: signing failed: Inappropriate ioctl for device\` because signing was bound unconditionally.