### PR TITLE
build: move source/javadoc plugins to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,23 +148,9 @@
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>3.1.1</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.8</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-						<configuration>
-							<bestPractices>true</bestPractices>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<releaseProfiles>release</releaseProfiles>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
@@ -177,6 +163,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,35 +53,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.12.0</version>
-				<configuration>
-					<encoding>UTF-8</encoding>
-					<docencoding>UTF-8</docencoding>
-					<charset>UTF-8</charset>
-				</configuration>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.5.5</version>
@@ -168,6 +139,35 @@
 			<id>release</id>
 			<build>
 				<plugins>
+					<plugin>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>3.3.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.12.0</version>
+						<configuration>
+							<encoding>UTF-8</encoding>
+							<docencoding>UTF-8</docencoding>
+							<charset>UTF-8</charset>
+						</configuration>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
## Summary
Move release-only plugins (source and javadoc jar generation) into the `release` profile so they run only during `release:perform`, completing the release configuration cleanup started by moving GPG signing into the profile.

## Changes Made
- Moved maven-source-plugin (`attach-sources`) and maven-javadoc-plugin (`attach-javadocs`) from the main build into the `release` profile, alongside maven-gpg-plugin
- maven-release-plugin already activates the profile via `<releaseProfiles>release</releaseProfiles>`, per the maven-release-plugin 2→3 migration guide (https://maven.apache.org/maven-release/maven-release-plugin/migrate.html)

## Testing
- `mvn package -DskipTests` — no sources/javadoc jars produced, no GPG required for local builds
- `mvn package -P release -DskipTests -Dgpg.skip=true` — sources and javadoc jars are produced

## Additional Notes
- Plain `mvn install` no longer attaches sources/javadoc jars locally; they are generated only during releases.
- The same standardization is applied across other CodeLibs repositories (corelib, curl4j, jcifs, jhighlight, nekohtml, spnego, java-saml, fess-parent).