### PR TITLE
feat(client): add PIT, reindex/by-query, resolve-index actions and fix request-param serialization

### DIFF
--- a/src/main/java/org/codelibs/fesen/client/HttpClient.java
+++ b/src/main/java/org/codelibs/fesen/client/HttpClient.java
@@ -57,11 +57,14 @@ import org.codelibs.fesen.client.action.HttpClusterHealthAction;
 import org.codelibs.fesen.client.action.HttpClusterRerouteAction;
 import org.codelibs.fesen.client.action.HttpClusterUpdateSettingsAction;
 import org.codelibs.fesen.client.action.HttpCreateIndexAction;
+import org.codelibs.fesen.client.action.HttpCreatePitAction;
 import org.codelibs.fesen.client.action.HttpCreateSnapshotAction;
 import org.codelibs.fesen.client.action.HttpDeleteAction;
+import org.codelibs.fesen.client.action.HttpDeleteByQueryAction;
 import org.codelibs.fesen.client.action.HttpDeleteIndexAction;
 import org.codelibs.fesen.client.action.HttpDeleteIndexTemplateAction;
 import org.codelibs.fesen.client.action.HttpDeletePipelineAction;
+import org.codelibs.fesen.client.action.HttpDeletePitAction;
 import org.codelibs.fesen.client.action.HttpDeleteRepositoryAction;
 import org.codelibs.fesen.client.action.HttpDeleteSnapshotAction;
 import org.codelibs.fesen.client.action.HttpDeleteStoredScriptAction;
@@ -71,6 +74,7 @@ import org.codelibs.fesen.client.action.HttpFlushAction;
 import org.codelibs.fesen.client.action.HttpForceMergeAction;
 import org.codelibs.fesen.client.action.HttpGetAction;
 import org.codelibs.fesen.client.action.HttpGetAliasesAction;
+import org.codelibs.fesen.client.action.HttpGetAllPitsAction;
 import org.codelibs.fesen.client.action.HttpGetFieldMappingsAction;
 import org.codelibs.fesen.client.action.HttpGetIndexAction;
 import org.codelibs.fesen.client.action.HttpGetIndexTemplatesAction;
@@ -128,6 +132,8 @@ import org.codelibs.fesen.client.action.HttpPutPipelineAction;
 import org.codelibs.fesen.client.action.HttpPutRepositoryAction;
 import org.codelibs.fesen.client.action.HttpPutStoredScriptAction;
 import org.codelibs.fesen.client.action.HttpRefreshAction;
+import org.codelibs.fesen.client.action.HttpReindexAction;
+import org.codelibs.fesen.client.action.HttpResolveIndexAction;
 import org.codelibs.fesen.client.action.HttpRestoreSnapshotAction;
 import org.codelibs.fesen.client.action.HttpRolloverAction;
 import org.codelibs.fesen.client.action.HttpSearchAction;
@@ -135,6 +141,7 @@ import org.codelibs.fesen.client.action.HttpSearchScrollAction;
 import org.codelibs.fesen.client.action.HttpSimulatePipelineAction;
 import org.codelibs.fesen.client.action.HttpSnapshotsStatusAction;
 import org.codelibs.fesen.client.action.HttpUpdateAction;
+import org.codelibs.fesen.client.action.HttpUpdateByQueryAction;
 import org.codelibs.fesen.client.action.HttpUpdateSettingsAction;
 import org.codelibs.fesen.client.action.HttpValidateQueryAction;
 import org.codelibs.fesen.client.action.HttpVerifyRepositoryAction;
@@ -290,6 +297,7 @@ import org.opensearch.action.admin.indices.open.OpenIndexResponse;
 import org.opensearch.action.admin.indices.refresh.RefreshAction;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshResponse;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.action.admin.indices.rollover.RolloverAction;
 import org.opensearch.action.admin.indices.rollover.RolloverRequest;
 import org.opensearch.action.admin.indices.rollover.RolloverResponse;
@@ -367,6 +375,15 @@ import org.opensearch.action.main.MainResponse;
 import org.opensearch.action.search.ClearScrollAction;
 import org.opensearch.action.search.ClearScrollRequest;
 import org.opensearch.action.search.ClearScrollResponse;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.CreatePitResponse;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.DeletePitResponse;
+import org.opensearch.action.search.GetAllPitNodesRequest;
+import org.opensearch.action.search.GetAllPitNodesResponse;
+import org.opensearch.action.search.GetAllPitsAction;
 import org.opensearch.action.search.MultiSearchAction;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
@@ -395,6 +412,13 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.xcontent.ContextParser;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.index.reindex.ReindexAction;
+import org.opensearch.index.reindex.ReindexRequest;
+import org.opensearch.index.reindex.UpdateByQueryAction;
+import org.opensearch.index.reindex.UpdateByQueryRequest;
 import org.opensearch.plugins.spi.NamedXContentProvider;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
@@ -1144,6 +1168,54 @@ public class HttpClient extends HttpAbstractClient {
         actions.put(RemoteStoreMetadataAction.INSTANCE, (request, listener) -> {
             new HttpRemoteStoreMetadataAction(this, RemoteStoreMetadataAction.INSTANCE).execute((RemoteStoreMetadataRequest) request,
                     (ActionListener<RemoteStoreMetadataResponse>) listener);
+        });
+
+        // Reindex / Update-By-Query / Delete-By-Query APIs
+        actions.put(ReindexAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.index.reindex.ReindexAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<BulkByScrollResponse> actionListener = (ActionListener<BulkByScrollResponse>) listener;
+            new HttpReindexAction(this, ReindexAction.INSTANCE).execute((ReindexRequest) request, actionListener);
+        });
+        actions.put(UpdateByQueryAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.index.reindex.UpdateByQueryAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<BulkByScrollResponse> actionListener = (ActionListener<BulkByScrollResponse>) listener;
+            new HttpUpdateByQueryAction(this, UpdateByQueryAction.INSTANCE).execute((UpdateByQueryRequest) request, actionListener);
+        });
+        actions.put(DeleteByQueryAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.index.reindex.DeleteByQueryAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<BulkByScrollResponse> actionListener = (ActionListener<BulkByScrollResponse>) listener;
+            new HttpDeleteByQueryAction(this, DeleteByQueryAction.INSTANCE).execute((DeleteByQueryRequest) request, actionListener);
+        });
+
+        // Point-in-Time (PIT) APIs
+        actions.put(CreatePitAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.action.search.CreatePitAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<CreatePitResponse> actionListener = (ActionListener<CreatePitResponse>) listener;
+            new HttpCreatePitAction(this, CreatePitAction.INSTANCE).execute((CreatePitRequest) request, actionListener);
+        });
+        actions.put(DeletePitAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.action.search.DeletePitAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<DeletePitResponse> actionListener = (ActionListener<DeletePitResponse>) listener;
+            new HttpDeletePitAction(this, DeletePitAction.INSTANCE).execute((DeletePitRequest) request, actionListener);
+        });
+        actions.put(GetAllPitsAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.action.search.GetAllPitsAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<GetAllPitNodesResponse> actionListener = (ActionListener<GetAllPitNodesResponse>) listener;
+            new HttpGetAllPitsAction(this, GetAllPitsAction.INSTANCE).execute((GetAllPitNodesRequest) request, actionListener);
+        });
+
+        // Resolve Index API
+        actions.put(ResolveIndexAction.INSTANCE, (request, listener) -> {
+            // org.opensearch.action.admin.indices.resolve.ResolveIndexAction
+            @SuppressWarnings("unchecked")
+            final ActionListener<ResolveIndexAction.Response> actionListener = (ActionListener<ResolveIndexAction.Response>) listener;
+            new HttpResolveIndexAction(this, ResolveIndexAction.INSTANCE).execute((ResolveIndexAction.Request) request, actionListener);
         });
     }
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpAction.java
@@ -27,6 +27,7 @@ import org.codelibs.fesen.client.io.stream.ByteArrayStreamOutput;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.ParseField;
@@ -243,6 +244,63 @@ public class HttpAction {
         } catch (final IOException e) {
             throw new OpenSearchException("Failed to parse a request.", e);
         }
+    }
+
+    /**
+     * Serializes an {@link ActiveShardCount} to its {@code wait_for_active_shards} query-parameter form:
+     * {@code "all"} for {@link ActiveShardCount#ALL}, otherwise the numeric value (e.g. {@code "0"} for NONE, {@code "2"} for a count).
+     *
+     * @param activeShardCount the active shard count to serialize
+     * @return the query-parameter string representation
+     */
+    protected String getActiveShardsCountString(final ActiveShardCount activeShardCount) {
+        if (ActiveShardCount.ALL.equals(activeShardCount)) {
+            return "all";
+        }
+        return Integer.toString(getActiveShardsCountValue(activeShardCount));
+    }
+
+    /**
+     * Appends the standard indices options query parameters ({@code ignore_unavailable},
+     * {@code allow_no_indices}, and {@code expand_wildcards}) to the given curl request.
+     *
+     * @param curlRequest the curl request to append the parameters to
+     * @param indicesOptions the indices options to serialize
+     */
+    protected void appendIndicesOptions(final CurlRequest curlRequest, final IndicesOptions indicesOptions) {
+        curlRequest.param("ignore_unavailable", Boolean.toString(indicesOptions.ignoreUnavailable()));
+        curlRequest.param("allow_no_indices", Boolean.toString(indicesOptions.allowNoIndices()));
+        curlRequest.param("expand_wildcards", expandWildcards(indicesOptions));
+    }
+
+    /**
+     * Serializes the wildcard expansion flags of the given indices options into the
+     * comma-separated {@code expand_wildcards} query parameter value.
+     *
+     * @param indicesOptions the indices options to serialize
+     * @return the {@code expand_wildcards} value ({@code none} when no wildcard state is enabled)
+     */
+    protected static String expandWildcards(final IndicesOptions indicesOptions) {
+        final StringBuilder buf = new StringBuilder();
+        if (indicesOptions.expandWildcardsOpen()) {
+            buf.append("open");
+        }
+        if (indicesOptions.expandWildcardsClosed()) {
+            if (buf.length() > 0) {
+                buf.append(',');
+            }
+            buf.append("closed");
+        }
+        if (indicesOptions.expandWildcardsHidden()) {
+            if (buf.length() > 0) {
+                buf.append(',');
+            }
+            buf.append("hidden");
+        }
+        if (buf.length() == 0) {
+            buf.append("none");
+        }
+        return buf.toString();
     }
 
     /**

--- a/src/main/java/org/codelibs/fesen/client/action/HttpBulkAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpBulkAction.java
@@ -266,13 +266,22 @@ public class HttpBulkAction extends HttpAction {
         // RestBulkAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_bulk");
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         if (request.timeout() != null) {
             curlRequest.param("timeout", request.timeout().toString());
         }
         if (!RefreshPolicy.NONE.equals(request.getRefreshPolicy())) {
             curlRequest.param("refresh", request.getRefreshPolicy().getValue());
+        }
+        if (request.pipeline() != null) {
+            curlRequest.param("pipeline", request.pipeline());
+        }
+        if (request.routing() != null) {
+            curlRequest.param("routing", request.routing());
+        }
+        if (request.requireAlias() != null && request.requireAlias().booleanValue()) {
+            curlRequest.param("require_alias", "true");
         }
         return curlRequest;
     }
@@ -311,7 +320,9 @@ public class HttpBulkAction extends HttpAction {
         if (request.ifPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
             appendStr(buf.append(','), "if_primary_term", request.ifPrimaryTerm());
         }
-        // retry_on_conflict
+        if (request.isRequireAlias()) {
+            buf.append(",\"require_alias\":true");
+        }
         switch (request.opType()) {
         case INDEX:
         case CREATE:
@@ -321,7 +332,10 @@ public class HttpBulkAction extends HttpAction {
             }
             break;
         case UPDATE:
-            // final UpdateRequest updateRequest = (UpdateRequest) request;
+            final UpdateRequest updateRequest = (UpdateRequest) request;
+            if (updateRequest.retryOnConflict() > 0) {
+                appendStr(buf.append(','), "retry_on_conflict", updateRequest.retryOnConflict());
+            }
             break;
         case DELETE:
             // final DeleteRequest deleteRequest = (DeleteRequest) request;

--- a/src/main/java/org/codelibs/fesen/client/action/HttpBulkByScrollAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpBulkByScrollAction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import java.io.IOException;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentHelper;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.AbstractBulkByScrollRequest;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+
+/**
+ * Base class for HTTP actions that return a {@link BulkByScrollResponse}, namely
+ * the reindex, update-by-query, and delete-by-query APIs. Provides shared response
+ * parsing, request-body serialization, and handling of the query parameters that are
+ * common to all bulk-by-scroll requests.
+ */
+public abstract class HttpBulkByScrollAction extends HttpAction {
+
+    /**
+     * Creates a new bulk-by-scroll HTTP action.
+     *
+     * @param client the HTTP client used to send requests
+     */
+    protected HttpBulkByScrollAction(final HttpClient client) {
+        super(client);
+    }
+
+    /**
+     * Parses a {@link BulkByScrollResponse} from the given XContent parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the parsed bulk-by-scroll response
+     */
+    protected BulkByScrollResponse fromXContent(final XContentParser parser) {
+        // BulkByScrollResponse.fromXContent(parser)
+        return BulkByScrollResponse.fromXContent(parser);
+    }
+
+    /**
+     * Serializes a request that implements {@link ToXContentObject} into a JSON string
+     * to be used as the HTTP request body.
+     *
+     * @param request the request to serialize
+     * @return the JSON representation of the request
+     */
+    protected String toSource(final ToXContentObject request) {
+        try {
+            return XContentHelper.toXContent(request, XContentType.JSON, ToXContent.EMPTY_PARAMS, false).utf8ToString();
+        } catch (final IOException e) {
+            throw new OpenSearchException("Failed to build a request.", e);
+        }
+    }
+
+    /**
+     * Adds the query parameters shared by all bulk-by-scroll requests. The response is
+     * always requested synchronously by forcing {@code wait_for_completion=true} so that
+     * the response body can be parsed as a {@link BulkByScrollResponse}.
+     *
+     * @param curlRequest the curl request to add parameters to
+     * @param request the bulk-by-scroll request providing the parameter values
+     */
+    protected void setCommonParams(final CurlRequest curlRequest, final AbstractBulkByScrollRequest<?> request) {
+        // AbstractBaseReindexRestHandler#setCommonOptions
+        curlRequest.param("wait_for_completion", "true");
+        if (request.isRefresh()) {
+            curlRequest.param("refresh", "true");
+        }
+        if (request.getTimeout() != null) {
+            curlRequest.param("timeout", request.getTimeout().toString());
+        }
+        if (!ActiveShardCount.DEFAULT.equals(request.getWaitForActiveShards())) {
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.getWaitForActiveShards()));
+        }
+        final float requestsPerSecond = request.getRequestsPerSecond();
+        if (!Float.isInfinite(requestsPerSecond)) {
+            curlRequest.param("requests_per_second", Float.toString(requestsPerSecond));
+        }
+        final int slices = request.getSlices();
+        if (slices != 1) {
+            curlRequest.param("slices", slices == AbstractBulkByScrollRequest.AUTO_SLICES ? AbstractBulkByScrollRequest.AUTO_SLICES_VALUE
+                    : Integer.toString(slices));
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpClusterHealthAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpClusterHealthAction.java
@@ -33,7 +33,6 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.health.ClusterStateHealth;
@@ -103,10 +102,7 @@ public class HttpClusterHealthAction extends HttpAction {
             }
         }
         if (request.waitForActiveShards() != null) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
-        }
-        if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", request.waitForActiveShards().toString());
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         if (request.waitForEvents() != null) {
             curlRequest.param("wait_for_events", request.waitForEvents().toString());

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCreateIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCreateIndexAction.java
@@ -164,7 +164,7 @@ public class HttpCreateIndexAction extends HttpAction {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         return curlRequest;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpCreatePitAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCreatePitAction.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import java.io.IOException;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitRequest;
+import org.opensearch.action.search.CreatePitResponse;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+
+/**
+ * Handles the Create Point-in-Time (PIT) API over HTTP, opening a PIT reader
+ * context over one or more indices that can be reused across search requests.
+ *
+ * <p>This action targets the OpenSearch REST API only. The
+ * {@code /{index}/_search/point_in_time} endpoint is OpenSearch-specific;
+ * Elasticsearch uses a different {@code _pit} endpoint and Elasticsearch 7 has
+ * no PIT support at all. No Elasticsearch adaptation is provided.
+ */
+public class HttpCreatePitAction extends HttpAction {
+
+    /** The create PIT action definition. */
+    protected final CreatePitAction action;
+
+    /**
+     * Creates a new HTTP create PIT action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the create PIT action definition
+     */
+    public HttpCreatePitAction(final HttpClient client, final CreatePitAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the create PIT request and notifies the listener with the response.
+     *
+     * @param request the create PIT request containing the target indices and keep-alive
+     * @param listener the listener notified with the response or a failure
+     */
+    public void execute(final CreatePitRequest request, final ActionListener<CreatePitResponse> listener) {
+        getCurlRequest(request).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                final CreatePitResponse pitResponse = fromXContent(parser);
+                listener.onResponse(pitResponse);
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Parses a create PIT response from the given XContent parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the parsed create PIT response
+     * @throws IOException if parsing the response fails
+     */
+    protected CreatePitResponse fromXContent(final XContentParser parser) throws IOException {
+        return CreatePitResponse.fromXContent(parser);
+    }
+
+    /**
+     * Builds the HTTP request for the create PIT API endpoint.
+     *
+     * @param request the create PIT request
+     * @return the configured curl request
+     */
+    protected CurlRequest getCurlRequest(final CreatePitRequest request) {
+        // RestCreatePitAction: POST /{index}/_search/point_in_time
+        final CurlRequest curlRequest = client.getCurlRequest(POST, "/_search/point_in_time", request.indices());
+        if (request.getKeepAlive() != null) {
+            curlRequest.param("keep_alive", request.getKeepAlive().getStringRep());
+        }
+        curlRequest.param("allow_partial_pit_creation", Boolean.toString(request.shouldAllowPartialPitCreation()));
+        if (request.getPreference() != null) {
+            curlRequest.param("preference", request.getPreference());
+        }
+        if (request.getRouting() != null) {
+            curlRequest.param("routing", request.getRouting());
+        }
+        final IndicesOptions indicesOptions = request.indicesOptions();
+        if (indicesOptions != null) {
+            appendIndicesOptions(curlRequest, indicesOptions);
+        }
+        return curlRequest;
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteAction.java
@@ -108,7 +108,7 @@ public class HttpDeleteAction extends HttpAction {
         curlRequest.param("if_seq_no", Long.toString(request.ifSeqNo()));
         curlRequest.param("if_primary_term", Long.toString(request.ifPrimaryTerm()));
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         return curlRequest.param("routing", request.routing()).param("version", String.valueOf(request.version()));
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteByQueryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteByQueryAction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.AbstractBulkByScrollRequest;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+
+/**
+ * Handles the delete-by-query API over HTTP for OpenSearch/Elasticsearch, deleting every
+ * document that matches a query.
+ */
+public class HttpDeleteByQueryAction extends HttpBulkByScrollAction {
+
+    /** The delete-by-query action definition. */
+    protected final DeleteByQueryAction action;
+
+    /**
+     * Creates a new HttpDeleteByQueryAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the delete-by-query action definition
+     */
+    public HttpDeleteByQueryAction(final HttpClient client, final DeleteByQueryAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the delete-by-query request and notifies the listener with the response.
+     *
+     * @param request the delete-by-query request
+     * @param listener the listener to notify with the response or a failure
+     */
+    public void execute(final DeleteByQueryRequest request, final ActionListener<BulkByScrollResponse> listener) {
+        getCurlRequest(request).body(toSource(request)).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                listener.onResponse(fromXContent(parser));
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Builds the curl request for the delete-by-query API. The query and {@code scroll_size}
+     * (as {@code size}) are carried in the request body produced by
+     * {@link DeleteByQueryRequest#toXContent}; the remaining settings are added as parameters.
+     *
+     * @param request the delete-by-query request
+     * @return the curl request for the delete-by-query endpoint
+     */
+    protected CurlRequest getCurlRequest(final DeleteByQueryRequest request) {
+        // RestDeleteByQueryAction
+        final CurlRequest curlRequest = client.getCurlRequest(POST, "/_delete_by_query", request.indices());
+        setCommonParams(curlRequest, request);
+        if (!request.isAbortOnVersionConflict()) {
+            curlRequest.param("conflicts", "proceed");
+        }
+        if (request.getMaxDocs() != AbstractBulkByScrollRequest.MAX_DOCS_ALL_MATCHES) {
+            curlRequest.param("max_docs", Integer.toString(request.getMaxDocs()));
+        }
+        if (request.getRouting() != null) {
+            curlRequest.param("routing", request.getRouting());
+        }
+        return curlRequest;
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeletePitAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeletePitAction.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitRequest;
+import org.opensearch.action.search.DeletePitResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+/**
+ * Handles the Delete Point-in-Time (PIT) API over HTTP, releasing one or more
+ * PIT reader contexts.
+ *
+ * <p>When the request targets the special {@code _all} identifier the delete-all
+ * endpoint {@code DELETE /_search/point_in_time/_all} is used with no body;
+ * otherwise the PIT identifiers are sent as a {@code {"pit_id":[...]}} body to
+ * {@code DELETE /_search/point_in_time}.
+ *
+ * <p>This action targets the OpenSearch REST API only. The
+ * {@code _search/point_in_time} endpoint is OpenSearch-specific; Elasticsearch
+ * uses a different {@code _pit} endpoint and Elasticsearch 7 has no PIT support
+ * at all. No Elasticsearch adaptation is provided.
+ */
+public class HttpDeletePitAction extends HttpAction {
+
+    /** The identifier used to request deletion of all PIT contexts. */
+    protected static final String ALL_PIT_IDS = "_all";
+
+    /** The delete PIT action definition. */
+    protected final DeletePitAction action;
+
+    /**
+     * Creates a new HTTP delete PIT action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the delete PIT action definition
+     */
+    public HttpDeletePitAction(final HttpClient client, final DeletePitAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the delete PIT request and notifies the listener with the response.
+     *
+     * @param request the delete PIT request containing the PIT identifiers to release
+     * @param listener the listener notified with the response or a failure
+     */
+    public void execute(final DeletePitRequest request, final ActionListener<DeletePitResponse> listener) {
+        final CurlRequest curlRequest = getCurlRequest(request);
+        if (!isDeleteAll(request)) {
+            curlRequest.body(buildBody(request));
+        }
+        curlRequest.execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                final DeletePitResponse pitResponse = fromXContent(parser);
+                listener.onResponse(pitResponse);
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Parses a delete PIT response from the given XContent parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the parsed delete PIT response
+     * @throws IOException if parsing the response fails
+     */
+    protected DeletePitResponse fromXContent(final XContentParser parser) throws IOException {
+        return DeletePitResponse.fromXContent(parser);
+    }
+
+    /**
+     * Builds the HTTP request for the delete PIT API endpoint. A delete-all request
+     * targets the {@code /_all} endpoint; otherwise the plain endpoint is used.
+     *
+     * @param request the delete PIT request
+     * @return the configured curl request
+     */
+    protected CurlRequest getCurlRequest(final DeletePitRequest request) {
+        // RestDeletePitAction
+        if (isDeleteAll(request)) {
+            return client.getCurlRequest(DELETE, "/_search/point_in_time/_all");
+        }
+        return client.getCurlRequest(DELETE, "/_search/point_in_time");
+    }
+
+    /**
+     * Determines whether the request represents a delete-all operation, that is a
+     * single PIT identifier equal to {@code _all}.
+     *
+     * @param request the delete PIT request
+     * @return {@code true} if the request should target the delete-all endpoint
+     */
+    protected static boolean isDeleteAll(final DeletePitRequest request) {
+        final List<String> pitIds = request.getPitIds();
+        return pitIds != null && pitIds.size() == 1 && ALL_PIT_IDS.equals(pitIds.get(0));
+    }
+
+    /**
+     * Serializes the delete PIT request body as a {@code {"pit_id":[...]}} JSON object.
+     *
+     * @param request the delete PIT request
+     * @return the JSON request body
+     */
+    protected String buildBody(final DeletePitRequest request) {
+        try (final XContentBuilder builder = JsonXContent.contentBuilder()) {
+            request.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.flush();
+            return BytesReference.bytes(builder).utf8ToString();
+        } catch (final IOException e) {
+            throw new OpenSearchException("Failed to build a request.", e);
+        }
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpExplainAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpExplainAction.java
@@ -35,6 +35,7 @@ import org.opensearch.core.xcontent.ConstructingObjectParser;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.get.GetResult;
+import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
 /**
  * Handles the explain API over HTTP for OpenSearch/Elasticsearch.
@@ -139,11 +140,21 @@ public class HttpExplainAction extends HttpAction {
         if (request.preference() != null) {
             curlRequest.param("preference", request.preference());
         }
-        if (request.query() != null) {
-            //
-        }
         if (request.storedFields() != null) {
             curlRequest.param("stored_fields", String.join(",", request.storedFields()));
+        }
+        final FetchSourceContext fetchSourceContext = request.fetchSourceContext();
+        if (fetchSourceContext != null) {
+            if (!fetchSourceContext.fetchSource()) {
+                curlRequest.param("_source", "false");
+            } else {
+                if (fetchSourceContext.includes().length > 0) {
+                    curlRequest.param("_source_includes", String.join(",", fetchSourceContext.includes()));
+                }
+                if (fetchSourceContext.excludes().length > 0) {
+                    curlRequest.param("_source_excludes", String.join(",", fetchSourceContext.excludes()));
+                }
+            }
         }
         return curlRequest;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesAction.java
@@ -15,12 +15,19 @@
  */
 package org.codelibs.fesen.client.action;
 
+import java.io.IOException;
+
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
 /**
@@ -49,7 +56,20 @@ public class HttpFieldCapabilitiesAction extends HttpAction {
      * @param listener the listener to notify with the field capabilities response or a failure
      */
     public void execute(final FieldCapabilitiesRequest request, final ActionListener<FieldCapabilitiesResponse> listener) {
-        getCurlRequest(request).execute(response -> {
+        final CurlRequest curlRequest = getCurlRequest(request);
+        if (request.indexFilter() != null) {
+            try (final XContentBuilder builder = JsonXContent.contentBuilder()) {
+                builder.startObject();
+                builder.field("index_filter");
+                request.indexFilter().toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.endObject();
+                builder.flush();
+                curlRequest.body(BytesReference.bytes(builder).utf8ToString());
+            } catch (final IOException e) {
+                throw new OpenSearchException("Failed to parse a request.", e);
+            }
+        }
+        curlRequest.execute(response -> {
             try (final XContentParser parser = createParser(response)) {
                 final FieldCapabilitiesResponse fieldCapabilitiesResponse = FieldCapabilitiesResponse.fromXContent(parser);
                 listener.onResponse(fieldCapabilitiesResponse);
@@ -71,6 +91,10 @@ public class HttpFieldCapabilitiesAction extends HttpAction {
         if (request.fields() != null) {
             curlRequest.param("fields", String.join(",", request.fields()));
         }
+        if (request.includeUnmapped()) {
+            curlRequest.param("include_unmapped", "true");
+        }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetAction.java
@@ -27,6 +27,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.VersionType;
+import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
 /**
  * Handles the Get Document API over HTTP for OpenSearch/Elasticsearch.
@@ -67,7 +68,13 @@ public class HttpGetAction extends HttpAction {
         }, e -> unwrapOpenSearchException(listener, e));
     }
 
-    private CurlRequest getCurlRequest(final GetRequest request) {
+    /**
+     * Builds the curl request for the get document API.
+     *
+     * @param request the get request
+     * @return the curl request
+     */
+    protected CurlRequest getCurlRequest(final GetRequest request) {
         // RestGetAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, "/_doc/" + UrlUtils.encode(request.id()), request.index());
         if (request.refresh()) {
@@ -90,6 +97,19 @@ public class HttpGetAction extends HttpAction {
         }
         if (!VersionType.INTERNAL.equals(request.versionType())) {
             curlRequest.param("version_type", request.versionType().name().toLowerCase(Locale.ROOT));
+        }
+        final FetchSourceContext fetchSourceContext = request.fetchSourceContext();
+        if (fetchSourceContext != null) {
+            if (!fetchSourceContext.fetchSource()) {
+                curlRequest.param("_source", "false");
+            } else {
+                if (fetchSourceContext.includes().length > 0) {
+                    curlRequest.param("_source_includes", String.join(",", fetchSourceContext.includes()));
+                }
+                if (fetchSourceContext.excludes().length > 0) {
+                    curlRequest.param("_source_excludes", String.join(",", fetchSourceContext.excludes()));
+                }
+            }
         }
         return curlRequest;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetAllPitsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetAllPitsAction.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import java.io.IOException;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.action.search.GetAllPitNodesRequest;
+import org.opensearch.action.search.GetAllPitNodesResponse;
+import org.opensearch.action.search.GetAllPitsAction;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+
+/**
+ * Handles the Get All Point-in-Time (PIT) API over HTTP, listing every active
+ * PIT reader context across the cluster.
+ *
+ * <p>This action targets the OpenSearch REST API only. The
+ * {@code /_search/point_in_time/_all} endpoint is OpenSearch-specific;
+ * Elasticsearch uses a different {@code _pit} endpoint and Elasticsearch 7 has
+ * no PIT support at all. No Elasticsearch adaptation is provided.
+ */
+public class HttpGetAllPitsAction extends HttpAction {
+
+    /** The get all PITs action definition. */
+    protected final GetAllPitsAction action;
+
+    /**
+     * Creates a new HTTP get all PITs action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the get all PITs action definition
+     */
+    public HttpGetAllPitsAction(final HttpClient client, final GetAllPitsAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the get all PITs request and notifies the listener with the response.
+     *
+     * @param request the get all PITs request
+     * @param listener the listener notified with the response or a failure
+     */
+    public void execute(final GetAllPitNodesRequest request, final ActionListener<GetAllPitNodesResponse> listener) {
+        getCurlRequest(request).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                final GetAllPitNodesResponse pitResponse = fromXContent(parser);
+                listener.onResponse(pitResponse);
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Parses a get all PITs response from the given XContent parser.
+     *
+     * @param parser the parser positioned at the response body
+     * @return the parsed get all PITs response
+     * @throws IOException if parsing the response fails
+     */
+    protected GetAllPitNodesResponse fromXContent(final XContentParser parser) throws IOException {
+        return GetAllPitNodesResponse.fromXContent(parser);
+    }
+
+    /**
+     * Builds the HTTP request for the get all PITs API endpoint.
+     *
+     * @param request the get all PITs request
+     * @return the configured curl request
+     */
+    protected CurlRequest getCurlRequest(final GetAllPitNodesRequest request) {
+        // RestGetAllPitsAction: GET /_search/point_in_time/_all
+        return client.getCurlRequest(GET, "/_search/point_in_time/_all");
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetSettingsAction.java
@@ -77,6 +77,7 @@ public class HttpGetSettingsAction extends HttpAction {
         if (request.masterNodeTimeout() != null) {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndexAction.java
@@ -36,6 +36,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.VersionType;
+import org.opensearch.index.seqno.SequenceNumbers;
 
 /**
  * Handles the index API over HTTP for OpenSearch/Elasticsearch,
@@ -132,10 +133,17 @@ public class HttpIndexAction extends HttpAction {
             curlRequest.param("version_type", request.versionType().name().toLowerCase(Locale.ROOT));
         }
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         if (request.id() != null) {
             curlRequest.param("op_type", opType.getLowercase());
+        }
+        if (request.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) {
+            curlRequest.param("if_seq_no", Long.toString(request.ifSeqNo()));
+            curlRequest.param("if_primary_term", Long.toString(request.ifPrimaryTerm()));
+        }
+        if (request.isRequireAlias()) {
+            curlRequest.param("require_alias", "true");
         }
         return curlRequest;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpMultiSearchAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpMultiSearchAction.java
@@ -165,6 +165,7 @@ public class HttpMultiSearchAction extends HttpAction {
     protected CurlRequest getCurlRequest(final MultiSearchRequest request) {
         // RestMultiSearchAction
         final CurlRequest curlRequest = client.getCurlRequest(GET, ContentType.X_NDJSON, "/_msearch");
+        curlRequest.param("typed_keys", "true");
         if (request.maxConcurrentSearchRequests() > 0) {
             curlRequest.param("max_concurrent_searches", Integer.toString(request.maxConcurrentSearchRequests()));
         }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutMappingAction.java
@@ -75,6 +75,10 @@ public class HttpPutMappingAction extends HttpAction {
         if (request.masterNodeTimeout() != null) {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
+        if (request.writeIndexOnly()) {
+            curlRequest.param("write_index_only", "true");
+        }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpReindexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpReindexAction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.ReindexAction;
+import org.opensearch.index.reindex.ReindexRequest;
+
+/**
+ * Handles the reindex API over HTTP for OpenSearch/Elasticsearch, copying documents
+ * from a source index (or a remote cluster) into a destination index.
+ */
+public class HttpReindexAction extends HttpBulkByScrollAction {
+
+    /** The reindex action definition. */
+    protected final ReindexAction action;
+
+    /**
+     * Creates a new HttpReindexAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the reindex action definition
+     */
+    public HttpReindexAction(final HttpClient client, final ReindexAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the reindex request and notifies the listener with the response.
+     *
+     * @param request the reindex request
+     * @param listener the listener to notify with the response or a failure
+     */
+    public void execute(final ReindexRequest request, final ActionListener<BulkByScrollResponse> listener) {
+        getCurlRequest(request).body(toSource(request)).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                listener.onResponse(fromXContent(parser));
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Builds the curl request for the reindex API. The source, destination, {@code max_docs},
+     * {@code conflicts}, and {@code script} settings are carried in the request body produced
+     * by {@link ReindexRequest#toXContent}; only the operational parameters are added here.
+     *
+     * @param request the reindex request
+     * @return the curl request for the reindex endpoint
+     */
+    protected CurlRequest getCurlRequest(final ReindexRequest request) {
+        // RestReindexAction
+        final CurlRequest curlRequest = client.getCurlRequest(POST, "/_reindex");
+        setCommonParams(curlRequest, request);
+        return curlRequest;
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpResolveIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpResolveIndexAction.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.codelibs.fesen.client.io.stream.ByteArrayStreamOutput;
+import org.codelibs.fesen.client.util.UrlUtils;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+
+/**
+ * Handles the Resolve Index API over HTTP for OpenSearch/Elasticsearch.
+ */
+public class HttpResolveIndexAction extends HttpAction {
+
+    /** The resolve index action definition. */
+    protected final ResolveIndexAction action;
+
+    /**
+     * Creates a new HTTP resolve index action.
+     *
+     * @param client the HTTP client used to send requests
+     * @param action the resolve index action definition
+     */
+    public HttpResolveIndexAction(final HttpClient client, final ResolveIndexAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the resolve index request asynchronously.
+     *
+     * @param request the resolve index request
+     * @param listener the listener notified with the resolve index response or a failure
+     */
+    public void execute(final ResolveIndexAction.Request request, final ActionListener<ResolveIndexAction.Response> listener) {
+        getCurlRequest(request).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                final ResolveIndexAction.Response resolveIndexResponse = fromXContent(parser);
+                listener.onResponse(resolveIndexResponse);
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Builds the curl request for the resolve index API.
+     *
+     * @param request the resolve index request
+     * @return the curl request to send
+     */
+    protected CurlRequest getCurlRequest(final ResolveIndexAction.Request request) {
+        // RestResolveIndexAction
+        final CurlRequest curlRequest = client.getCurlRequest(GET, "/_resolve/index/" + UrlUtils.joinAndEncode(",", request.indices()));
+        appendIndicesOptions(curlRequest, request.indicesOptions());
+        return curlRequest;
+    }
+
+    /**
+     * Parses the HTTP response body into a {@link ResolveIndexAction.Response}.
+     *
+     * <p>{@link ResolveIndexAction.Response} does not expose a {@code fromXContent} method and the
+     * element types ({@code ResolvedIndex}, {@code ResolvedAlias}, {@code ResolvedDataStream}) have
+     * package-private constructors, so the parsed values are re-serialized into the transport wire
+     * format and read back through the response reader.</p>
+     *
+     * @param parser the content parser for the response body
+     * @return the parsed resolve index response
+     * @throws IOException if parsing fails
+     */
+    protected ResolveIndexAction.Response fromXContent(final XContentParser parser) throws IOException {
+        final List<ResolvedIndexData> indices = new ArrayList<>();
+        final List<ResolvedAliasData> aliases = new ArrayList<>();
+        final List<ResolvedDataStreamData> dataStreams = new ArrayList<>();
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if ("indices".equals(fieldName)) {
+                    parseIndices(parser, indices);
+                } else if ("aliases".equals(fieldName)) {
+                    parseAliases(parser, aliases);
+                } else if ("data_streams".equals(fieldName)) {
+                    parseDataStreams(parser, dataStreams);
+                } else {
+                    parser.skipChildren();
+                }
+            }
+        }
+
+        try (final ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
+            out.writeVInt(indices.size());
+            for (final ResolvedIndexData data : indices) {
+                out.writeString(data.name);
+                out.writeStringArray(data.aliases.toArray(new String[0]));
+                out.writeStringArray(data.attributes.toArray(new String[0]));
+                out.writeOptionalString(data.dataStream);
+            }
+            out.writeVInt(aliases.size());
+            for (final ResolvedAliasData data : aliases) {
+                out.writeString(data.name);
+                out.writeStringArray(data.indices.toArray(new String[0]));
+            }
+            out.writeVInt(dataStreams.size());
+            for (final ResolvedDataStreamData data : dataStreams) {
+                out.writeString(data.name);
+                out.writeStringArray(data.backingIndices.toArray(new String[0]));
+                out.writeString(data.timestampField);
+            }
+            return action.getResponseReader().read(out.toStreamInput());
+        }
+    }
+
+    /**
+     * Parses the {@code indices} array of the response body.
+     *
+     * @param parser the content parser positioned at the {@code indices} array start
+     * @param indices the list to append parsed resolved indices to
+     * @throws IOException if parsing fails
+     */
+    protected static void parseIndices(final XContentParser parser, final List<ResolvedIndexData> indices) throws IOException {
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            final ResolvedIndexData data = new ResolvedIndexData();
+            String fieldName = null;
+            XContentParser.Token token;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    fieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    if ("aliases".equals(fieldName)) {
+                        data.aliases = readStringArray(parser);
+                    } else if ("attributes".equals(fieldName)) {
+                        data.attributes = readStringArray(parser);
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.VALUE_STRING) {
+                    if ("name".equals(fieldName)) {
+                        data.name = parser.text();
+                    } else if ("data_stream".equals(fieldName)) {
+                        data.dataStream = parser.text();
+                    }
+                }
+            }
+            indices.add(data);
+        }
+    }
+
+    /**
+     * Parses the {@code aliases} array of the response body.
+     *
+     * @param parser the content parser positioned at the {@code aliases} array start
+     * @param aliases the list to append parsed resolved aliases to
+     * @throws IOException if parsing fails
+     */
+    protected static void parseAliases(final XContentParser parser, final List<ResolvedAliasData> aliases) throws IOException {
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            final ResolvedAliasData data = new ResolvedAliasData();
+            String fieldName = null;
+            XContentParser.Token token;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    fieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    if ("indices".equals(fieldName)) {
+                        data.indices = readStringArray(parser);
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.VALUE_STRING && "name".equals(fieldName)) {
+                    data.name = parser.text();
+                }
+            }
+            aliases.add(data);
+        }
+    }
+
+    /**
+     * Parses the {@code data_streams} array of the response body.
+     *
+     * @param parser the content parser positioned at the {@code data_streams} array start
+     * @param dataStreams the list to append parsed resolved data streams to
+     * @throws IOException if parsing fails
+     */
+    protected static void parseDataStreams(final XContentParser parser, final List<ResolvedDataStreamData> dataStreams) throws IOException {
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            final ResolvedDataStreamData data = new ResolvedDataStreamData();
+            String fieldName = null;
+            XContentParser.Token token;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    fieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_ARRAY) {
+                    if ("backing_indices".equals(fieldName)) {
+                        data.backingIndices = readStringArray(parser);
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.VALUE_STRING) {
+                    if ("name".equals(fieldName)) {
+                        data.name = parser.text();
+                    } else if ("timestamp_field".equals(fieldName)) {
+                        data.timestampField = parser.text();
+                    }
+                }
+            }
+            dataStreams.add(data);
+        }
+    }
+
+    /**
+     * Reads a JSON array of string values into a list.
+     *
+     * @param parser the content parser positioned at the array start
+     * @return the list of parsed string values
+     * @throws IOException if parsing fails
+     */
+    protected static List<String> readStringArray(final XContentParser parser) throws IOException {
+        final List<String> values = new ArrayList<>();
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            values.add(parser.text());
+        }
+        return values;
+    }
+
+    /**
+     * Internal container holding the parsed fields of a resolved index entry.
+     */
+    protected static class ResolvedIndexData {
+        String name;
+        List<String> aliases = new ArrayList<>();
+        List<String> attributes = new ArrayList<>();
+        String dataStream;
+    }
+
+    /**
+     * Internal container holding the parsed fields of a resolved alias entry.
+     */
+    protected static class ResolvedAliasData {
+        String name;
+        List<String> indices = new ArrayList<>();
+    }
+
+    /**
+     * Internal container holding the parsed fields of a resolved data stream entry.
+     */
+    protected static class ResolvedDataStreamData {
+        String name;
+        List<String> backingIndices = new ArrayList<>();
+        String timestampField;
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRolloverAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRolloverAction.java
@@ -104,8 +104,7 @@ public class HttpRolloverAction extends HttpAction {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
         if (!ActiveShardCount.DEFAULT.equals(request.getCreateIndexRequest().waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards",
-                    String.valueOf(getActiveShardsCountValue(request.getCreateIndexRequest().waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.getCreateIndexRequest().waitForActiveShards()));
         }
         return curlRequest;
     }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
@@ -125,6 +125,7 @@ public class HttpSearchAction extends HttpAction {
             curlRequest.param("preference", request.preference());
         }
         curlRequest.param("ccs_minimize_roundtrips", Boolean.toString(request.isCcsMinimizeRoundtrips()));
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
@@ -118,7 +118,7 @@ public class HttpUpdateAction extends HttpAction {
             curlRequest.param("refresh", request.getRefreshPolicy().getValue());
         }
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", String.valueOf(getActiveShardsCountValue(request.waitForActiveShards())));
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
         curlRequest.param("doc_as_upsert", Boolean.toString(request.docAsUpsert()));
         curlRequest.param("retry_on_conflict", String.valueOf(request.retryOnConflict()));

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateByQueryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateByQueryAction.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.AbstractBulkByScrollRequest;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.UpdateByQueryAction;
+import org.opensearch.index.reindex.UpdateByQueryRequest;
+
+/**
+ * Handles the update-by-query API over HTTP for OpenSearch/Elasticsearch, updating every
+ * document that matches a query, optionally applying a script.
+ */
+public class HttpUpdateByQueryAction extends HttpBulkByScrollAction {
+
+    /** The update-by-query action definition. */
+    protected final UpdateByQueryAction action;
+
+    /**
+     * Creates a new HttpUpdateByQueryAction.
+     *
+     * @param client the HTTP client to send requests with
+     * @param action the update-by-query action definition
+     */
+    public HttpUpdateByQueryAction(final HttpClient client, final UpdateByQueryAction action) {
+        super(client);
+        this.action = action;
+    }
+
+    /**
+     * Executes the update-by-query request and notifies the listener with the response.
+     *
+     * @param request the update-by-query request
+     * @param listener the listener to notify with the response or a failure
+     */
+    public void execute(final UpdateByQueryRequest request, final ActionListener<BulkByScrollResponse> listener) {
+        getCurlRequest(request).body(toSource(request)).execute(response -> {
+            try (final XContentParser parser = createParser(response)) {
+                listener.onResponse(fromXContent(parser));
+            } catch (final Exception e) {
+                listener.onFailure(toOpenSearchException(response, e));
+            }
+        }, e -> unwrapOpenSearchException(listener, e));
+    }
+
+    /**
+     * Builds the curl request for the update-by-query API. The query, {@code script}, and
+     * {@code scroll_size} (as {@code size}) are carried in the request body produced by
+     * {@link UpdateByQueryRequest#toXContent}; the remaining settings are added as parameters.
+     *
+     * @param request the update-by-query request
+     * @return the curl request for the update-by-query endpoint
+     */
+    protected CurlRequest getCurlRequest(final UpdateByQueryRequest request) {
+        // RestUpdateByQueryAction
+        final CurlRequest curlRequest = client.getCurlRequest(POST, "/_update_by_query", request.indices());
+        setCommonParams(curlRequest, request);
+        if (!request.isAbortOnVersionConflict()) {
+            curlRequest.param("conflicts", "proceed");
+        }
+        if (request.getMaxDocs() != AbstractBulkByScrollRequest.MAX_DOCS_ALL_MATCHES) {
+            curlRequest.param("max_docs", Integer.toString(request.getMaxDocs()));
+        }
+        if (request.getRouting() != null) {
+            curlRequest.param("routing", request.getRouting());
+        }
+        if (request.getPipeline() != null) {
+            curlRequest.param("pipeline", request.getPipeline());
+        }
+        return curlRequest;
+    }
+}

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateSettingsAction.java
@@ -89,6 +89,7 @@ public class HttpUpdateSettingsAction extends HttpAction {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
         curlRequest.param("preserve_existing", Boolean.toString(request.isPreserveExisting()));
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/test/java/org/codelibs/fesen/client/action/ActionTestUtils.java
+++ b/src/test/java/org/codelibs/fesen/client/action/ActionTestUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import java.lang.reflect.Field;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.HttpClient;
+import org.codelibs.fesen.client.HttpClient.ContentType;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Test helpers for inspecting the {@link CurlRequest} that an {@code HttpXxxAction}
+ * builds from an OpenSearch request, without requiring a running cluster.
+ *
+ * <p>The returned {@link HttpClient} overrides {@link HttpClient#getCurlRequest} so that a
+ * plain {@link CurlRequest} (with no node manager) is produced, allowing the query
+ * parameters and body assembled by an action to be examined offline.</p>
+ */
+final class ActionTestUtils {
+
+    private static volatile HttpClient client;
+
+    private ActionTestUtils() {
+    }
+
+    /**
+     * Returns a shared {@link HttpClient} that builds plain, inspectable curl requests.
+     *
+     * @return the test HTTP client
+     */
+    static HttpClient testClient() {
+        if (client == null) {
+            synchronized (ActionTestUtils.class) {
+                if (client == null) {
+                    client = createClient();
+                }
+            }
+        }
+        return client;
+    }
+
+    private static HttpClient createClient() {
+        final Settings settings = Settings.builder().putList("http.hosts", "localhost:9200").build();
+        return new HttpClient(settings, null) {
+            @Override
+            public CurlRequest getCurlRequest(final Function<String, CurlRequest> method, final ContentType contentType, final String path,
+                    final String... indices) {
+                final StringBuilder buf = new StringBuilder("http://localhost");
+                if (indices.length > 0) {
+                    buf.append('/').append(String.join(",", indices));
+                }
+                if (path != null) {
+                    buf.append(path);
+                }
+                return method.apply(buf.toString());
+            }
+        };
+    }
+
+    /**
+     * Returns the raw {@code key=value} query parameter list of the given curl request,
+     * read reflectively from the protected {@code paramList} field.
+     *
+     * @param request the curl request to inspect
+     * @return the raw (URL-encoded) parameter entries, never {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    static List<String> rawParams(final CurlRequest request) {
+        try {
+            final Field field = CurlRequest.class.getDeclaredField("paramList");
+            field.setAccessible(true);
+            final List<String> list = (List<String>) field.get(request);
+            return list == null ? new ArrayList<>() : list;
+        } catch (final ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns the decoded query parameters of the given curl request as a map.
+     *
+     * @param request the curl request to inspect
+     * @return a map of decoded parameter names to decoded values
+     */
+    static Map<String, String> params(final CurlRequest request) {
+        final Map<String, String> map = new LinkedHashMap<>();
+        for (final String param : rawParams(request)) {
+            final int idx = param.indexOf('=');
+            final String key = decode(param.substring(0, idx));
+            final String value = decode(param.substring(idx + 1));
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    private static String decode(final String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpActionTest.java
@@ -110,6 +110,21 @@ class HttpActionTest {
     }
 
     @Test
+    void test_getActiveShardsCountString_all() {
+        assertEquals("all", action.getActiveShardsCountString(ActiveShardCount.ALL));
+    }
+
+    @Test
+    void test_getActiveShardsCountString_none() {
+        assertEquals("0", action.getActiveShardsCountString(ActiveShardCount.NONE));
+    }
+
+    @Test
+    void test_getActiveShardsCountString_customValue() {
+        assertEquals("2", action.getActiveShardsCountString(ActiveShardCount.from(2)));
+    }
+
+    @Test
     void test_unwrapOpenSearchException_withOpenSearchCause() {
         final OpenSearchException cause = new OpenSearchException("inner error");
         final Exception wrapper = new RuntimeException("outer", cause);

--- a/src/test/java/org/codelibs/fesen/client/action/HttpBulkActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpBulkActionTest.java
@@ -21,12 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.bulk.BulkAction;
+import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -36,6 +39,36 @@ import org.opensearch.core.xcontent.XContentParser;
 class HttpBulkActionTest {
 
     private final HttpBulkAction action = new HttpBulkAction(null, BulkAction.INSTANCE);
+
+    private final HttpBulkAction clientAction = new HttpBulkAction(ActionTestUtils.testClient(), BulkAction.INSTANCE);
+
+    @Test
+    void test_getStringfromDocWriteRequest_updateRetryOnConflict() {
+        final UpdateRequest request = new UpdateRequest("test-index", "doc1").retryOnConflict(3);
+        final String result = action.getStringfromDocWriteRequest(request);
+        assertTrue(result.contains("\"update\""));
+        assertTrue(result.contains("\"retry_on_conflict\":3"));
+    }
+
+    @Test
+    void test_getStringfromDocWriteRequest_requireAlias() {
+        final IndexRequest request =
+                new IndexRequest("test-index").id("doc1").setRequireAlias(true).source("{\"field\":\"value\"}", XContentType.JSON);
+        final String result = action.getStringfromDocWriteRequest(request);
+        assertTrue(result.contains("\"require_alias\":true"));
+    }
+
+    @Test
+    void test_getCurlRequest_globalPipelineRoutingRequireAlias() {
+        final BulkRequest request = new BulkRequest();
+        request.pipeline("my-pipeline");
+        request.routing("r1");
+        request.requireAlias(true);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("my-pipeline", params.get("pipeline"));
+        assertEquals("r1", params.get("routing"));
+        assertEquals("true", params.get("require_alias"));
+    }
 
     @Test
     void test_getStringfromDocWriteRequest_indexWithId() {

--- a/src/test/java/org/codelibs/fesen/client/action/HttpCreatePitActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpCreatePitActionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.CreatePitAction;
+import org.opensearch.action.search.CreatePitResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+
+class HttpCreatePitActionTest {
+
+    private final HttpCreatePitAction action = new HttpCreatePitAction(null, CreatePitAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws IOException {
+        final String json = "{\"pit_id\":\"abc\",\"_shards\":{\"total\":2,\"successful\":2,\"skipped\":0,\"failed\":0},"
+                + "\"creation_time\":1720000000000}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final CreatePitResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals("abc", response.getId());
+            assertEquals(1720000000000L, response.getCreationTime());
+            assertEquals(2, response.getTotalShards());
+            assertEquals(2, response.getSuccessfulShards());
+            assertEquals(0, response.getSkippedShards());
+            assertEquals(0, response.getFailedShards());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpDeleteByQueryActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpDeleteByQueryActionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+
+class HttpDeleteByQueryActionTest {
+
+    private final HttpDeleteByQueryAction action = new HttpDeleteByQueryAction(null, DeleteByQueryAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws Exception {
+        final String json = "{\"took\":210,\"timed_out\":false,\"total\":75,\"updated\":0,\"created\":0,\"deleted\":75,"
+                + "\"batches\":1,\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":0},"
+                + "\"throttled_millis\":0,\"requests_per_second\":-1.0,\"throttled_until_millis\":0,\"failures\":[]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final BulkByScrollResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(210L, response.getTook().millis());
+            assertFalse(response.isTimedOut());
+            assertEquals(75L, response.getTotal());
+            assertEquals(75L, response.getDeleted());
+            assertEquals(0L, response.getUpdated());
+            assertEquals(0L, response.getCreated());
+            assertEquals(1, response.getBatches());
+            assertEquals(0L, response.getVersionConflicts());
+            assertEquals(0L, response.getNoops());
+            assertEquals(0L, response.getBulkRetries());
+            assertEquals(0L, response.getSearchRetries());
+            assertEquals(0, response.getBulkFailures().size());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpDeletePitActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpDeletePitActionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.DeletePitAction;
+import org.opensearch.action.search.DeletePitResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+
+class HttpDeletePitActionTest {
+
+    private final HttpDeletePitAction action = new HttpDeletePitAction(null, DeletePitAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws IOException {
+        final String json = "{\"pits\":[{\"successful\":true,\"pit_id\":\"abc\"},{\"successful\":false,\"pit_id\":\"def\"}]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final DeletePitResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(2, response.getDeletePitResults().size());
+            assertTrue(response.getDeletePitResults().get(0).isSuccessful());
+            assertEquals("abc", response.getDeletePitResults().get(0).getPitId());
+            assertEquals(false, response.getDeletePitResults().get(1).isSuccessful());
+            assertEquals("def", response.getDeletePitResults().get(1).getPitId());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpExplainActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpExplainActionTest.java
@@ -17,48 +17,32 @@ package org.codelibs.fesen.client.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.opensearch.action.get.GetAction;
-import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.explain.ExplainAction;
+import org.opensearch.action.explain.ExplainRequest;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 
-class HttpGetActionTest {
+class HttpExplainActionTest {
 
-    private final HttpGetAction clientAction = new HttpGetAction(ActionTestUtils.testClient(), GetAction.INSTANCE);
-
-    @Test
-    void test_construction() {
-        final HttpGetAction action = new HttpGetAction(null, GetAction.INSTANCE);
-        assertNotNull(action);
-    }
+    private final HttpExplainAction clientAction = new HttpExplainAction(ActionTestUtils.testClient(), ExplainAction.INSTANCE);
 
     @Test
     void test_getCurlRequest_sourceIncludesExcludes() {
-        final GetRequest request = new GetRequest("test-index", "1")
-                .fetchSourceContext(new FetchSourceContext(true, new String[] { "field1", "field2" }, new String[] { "excluded" }));
+        final ExplainRequest request = new ExplainRequest("test-index", "1")
+                .fetchSourceContext(new FetchSourceContext(true, new String[] { "field1" }, new String[] { "excluded" }));
         final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
-        assertEquals("field1,field2", params.get("_source_includes"));
+        assertEquals("field1", params.get("_source_includes"));
         assertEquals("excluded", params.get("_source_excludes"));
     }
 
     @Test
     void test_getCurlRequest_sourceDisabled() {
-        final GetRequest request = new GetRequest("test-index", "1").fetchSourceContext(new FetchSourceContext(false));
+        final ExplainRequest request = new ExplainRequest("test-index", "1").fetchSourceContext(new FetchSourceContext(false));
         final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
         assertEquals("false", params.get("_source"));
         assertFalse(params.containsKey("_source_includes"));
-    }
-
-    @Test
-    void test_getCurlRequest_storedFieldsAndPreference() {
-        final GetRequest request = new GetRequest("test-index", "1").storedFields("f1", "f2").preference("_local").routing("r1");
-        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
-        assertEquals("f1,f2", params.get("stored_fields"));
-        assertEquals("_local", params.get("preference"));
-        assertEquals("r1", params.get("routing"));
     }
 }

--- a/src/test/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpFieldCapabilitiesActionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.fieldcaps.FieldCapabilitiesAction;
+import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
+
+class HttpFieldCapabilitiesActionTest {
+
+    private final HttpFieldCapabilitiesAction clientAction =
+            new HttpFieldCapabilitiesAction(ActionTestUtils.testClient(), FieldCapabilitiesAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_includeUnmappedAndIndicesOptions() {
+        final FieldCapabilitiesRequest request =
+                new FieldCapabilitiesRequest().indices("test-index").fields("f1", "f2").includeUnmapped(true);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("true", params.get("include_unmapped"));
+        assertEquals("f1,f2", params.get("fields"));
+        assertTrue(params.containsKey("expand_wildcards"));
+        assertTrue(params.containsKey("ignore_unavailable"));
+        assertTrue(params.containsKey("allow_no_indices"));
+    }
+
+    @Test
+    void test_getCurlRequest_includeUnmappedDefaultNotSent() {
+        final FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices("test-index").fields("f1");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals(null, params.get("include_unmapped"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpGetAllPitsActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpGetAllPitsActionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.GetAllPitNodesResponse;
+import org.opensearch.action.search.GetAllPitsAction;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+
+class HttpGetAllPitsActionTest {
+
+    private final HttpGetAllPitsAction action = new HttpGetAllPitsAction(null, GetAllPitsAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws IOException {
+        final String json = "{\"pits\":[{\"pit_id\":\"abc\",\"creation_time\":123,\"keep_alive\":300000}]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final GetAllPitNodesResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(1, response.getPitInfos().size());
+            assertEquals("abc", response.getPitInfos().get(0).getPitId());
+            assertEquals(123L, response.getPitInfos().get(0).getCreationTime());
+            assertEquals(300000L, response.getPitInfos().get(0).getKeepAlive());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpGetSettingsActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpGetSettingsActionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsAction;
+import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest;
+
+class HttpGetSettingsActionTest {
+
+    private final HttpGetSettingsAction clientAction = new HttpGetSettingsAction(ActionTestUtils.testClient(), GetSettingsAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptions() {
+        final GetSettingsRequest request = new GetSettingsRequest().indices("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertTrue(params.containsKey("expand_wildcards"));
+        assertTrue(params.containsKey("ignore_unavailable"));
+        assertTrue(params.containsKey("allow_no_indices"));
+        assertTrue(params.containsKey("include_defaults"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpIndexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpIndexActionTest.java
@@ -16,12 +16,15 @@
 package org.codelibs.fesen.client.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.index.IndexAction;
+import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -31,6 +34,31 @@ import org.opensearch.core.xcontent.XContentParser;
 class HttpIndexActionTest {
 
     private final HttpIndexAction action = new HttpIndexAction(null, IndexAction.INSTANCE);
+
+    private final HttpIndexAction clientAction = new HttpIndexAction(ActionTestUtils.testClient(), IndexAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_ifSeqNoAndPrimaryTerm() {
+        final IndexRequest request = new IndexRequest("test-index").id("1").setIfSeqNo(5L).setIfPrimaryTerm(2L);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("5", params.get("if_seq_no"));
+        assertEquals("2", params.get("if_primary_term"));
+    }
+
+    @Test
+    void test_getCurlRequest_ifSeqNoUnassignedNotSent() {
+        final IndexRequest request = new IndexRequest("test-index").id("1");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertFalse(params.containsKey("if_seq_no"));
+        assertFalse(params.containsKey("if_primary_term"));
+    }
+
+    @Test
+    void test_getCurlRequest_requireAlias() {
+        final IndexRequest request = new IndexRequest("test-index").id("1").setRequireAlias(true);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("true", params.get("require_alias"));
+    }
 
     @Test
     void test_fromXContent_created() throws IOException {

--- a/src/test/java/org/codelibs/fesen/client/action/HttpMultiSearchActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpMultiSearchActionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.MultiSearchAction;
+import org.opensearch.action.search.MultiSearchRequest;
+
+class HttpMultiSearchActionTest {
+
+    private final HttpMultiSearchAction clientAction = new HttpMultiSearchAction(ActionTestUtils.testClient(), MultiSearchAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_typedKeys() {
+        final MultiSearchRequest request = new MultiSearchRequest();
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("true", params.get("typed_keys"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpPutMappingActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpPutMappingActionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingAction;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+
+class HttpPutMappingActionTest {
+
+    private final HttpPutMappingAction clientAction = new HttpPutMappingAction(ActionTestUtils.testClient(), PutMappingAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_writeIndexOnlyAndIndicesOptions() {
+        final PutMappingRequest request = new PutMappingRequest("test-index").writeIndexOnly(true);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("true", params.get("write_index_only"));
+        assertTrue(params.containsKey("expand_wildcards"));
+        assertTrue(params.containsKey("ignore_unavailable"));
+        assertTrue(params.containsKey("allow_no_indices"));
+    }
+
+    @Test
+    void test_getCurlRequest_writeIndexOnlyDefaultNotSent() {
+        final PutMappingRequest request = new PutMappingRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals(null, params.get("write_index_only"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpReindexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpReindexActionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.ReindexAction;
+
+class HttpReindexActionTest {
+
+    private final HttpReindexAction action = new HttpReindexAction(null, ReindexAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws Exception {
+        final String json = "{\"took\":147,\"timed_out\":false,\"total\":120,\"updated\":0,\"created\":120,\"deleted\":0,"
+                + "\"batches\":1,\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":0},"
+                + "\"throttled_millis\":0,\"requests_per_second\":-1.0,\"throttled_until_millis\":0,\"failures\":[]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final BulkByScrollResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(147L, response.getTook().millis());
+            assertFalse(response.isTimedOut());
+            assertEquals(120L, response.getTotal());
+            assertEquals(120L, response.getCreated());
+            assertEquals(0L, response.getUpdated());
+            assertEquals(0L, response.getDeleted());
+            assertEquals(1, response.getBatches());
+            assertEquals(0L, response.getVersionConflicts());
+            assertEquals(0L, response.getNoops());
+            assertEquals(0L, response.getBulkRetries());
+            assertEquals(0L, response.getSearchRetries());
+            assertEquals(0, response.getBulkFailures().size());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpResolveIndexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpResolveIndexActionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction.ResolvedAlias;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction.ResolvedDataStream;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction.ResolvedIndex;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+
+class HttpResolveIndexActionTest {
+
+    private final HttpResolveIndexAction action = new HttpResolveIndexAction(null, ResolveIndexAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws IOException {
+        final String json = "{" //
+                + "\"indices\":[{\"name\":\"idx1\",\"aliases\":[\"a1\"],\"attributes\":[\"open\"],\"data_stream\":\"ds1\"}]," //
+                + "\"aliases\":[{\"name\":\"a1\",\"indices\":[\"idx1\"]}]," //
+                + "\"data_streams\":[{\"name\":\"ds1\",\"backing_indices\":[\"idx1\"],\"timestamp_field\":\"@timestamp\"}]" //
+                + "}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final ResolveIndexAction.Response response = action.fromXContent(parser);
+            assertNotNull(response);
+
+            assertEquals(1, response.getIndices().size());
+            final ResolvedIndex index = response.getIndices().get(0);
+            assertEquals("idx1", index.getName());
+            assertArrayEquals(new String[] { "a1" }, index.getAliases());
+            assertArrayEquals(new String[] { "open" }, index.getAttributes());
+            assertEquals("ds1", index.getDataStream());
+
+            assertEquals(1, response.getAliases().size());
+            final ResolvedAlias alias = response.getAliases().get(0);
+            assertEquals("a1", alias.getName());
+            assertArrayEquals(new String[] { "idx1" }, alias.getIndices());
+
+            assertEquals(1, response.getDataStreams().size());
+            final ResolvedDataStream dataStream = response.getDataStreams().get(0);
+            assertEquals("ds1", dataStream.getName());
+            assertArrayEquals(new String[] { "idx1" }, dataStream.getBackingIndices());
+            assertEquals("@timestamp", dataStream.getTimestampField());
+        }
+    }
+
+    @Test
+    void test_fromXContent_empty() throws IOException {
+        final String json = "{\"indices\":[],\"aliases\":[],\"data_streams\":[]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final ResolveIndexAction.Response response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(0, response.getIndices().size());
+            assertEquals(0, response.getAliases().size());
+            assertEquals(0, response.getDataStreams().size());
+        }
+    }
+
+    @Test
+    void test_fromXContent_indexWithoutOptionalFields() throws IOException {
+        // ResolvedIndex.toXContent omits "aliases" and "data_stream" when they are empty/null.
+        final String json = "{\"indices\":[{\"name\":\"idx1\",\"attributes\":[\"open\",\"hidden\"]}],\"aliases\":[],\"data_streams\":[]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final ResolveIndexAction.Response response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(1, response.getIndices().size());
+            final ResolvedIndex index = response.getIndices().get(0);
+            assertEquals("idx1", index.getName());
+            assertArrayEquals(new String[0], index.getAliases());
+            assertArrayEquals(new String[] { "open", "hidden" }, index.getAttributes());
+            assertEquals(null, index.getDataStream());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpSearchActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpSearchActionTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
@@ -28,6 +30,18 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 class HttpSearchActionTest {
 
     private final HttpSearchAction action = new HttpSearchAction(null, SearchAction.INSTANCE);
+
+    private final HttpSearchAction clientAction = new HttpSearchAction(ActionTestUtils.testClient(), SearchAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptionsAndTypedKeys() {
+        final SearchRequest request = new SearchRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("open", params.get("expand_wildcards"));
+        assertEquals("false", params.get("ignore_unavailable"));
+        assertEquals("true", params.get("allow_no_indices"));
+        assertEquals("true", params.get("typed_keys"));
+    }
 
     @Test
     void test_getQuerySource_withDefaultSource() {

--- a/src/test/java/org/codelibs/fesen/client/action/HttpUpdateByQueryActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpUpdateByQueryActionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.UpdateByQueryAction;
+
+class HttpUpdateByQueryActionTest {
+
+    private final HttpUpdateByQueryAction action = new HttpUpdateByQueryAction(null, UpdateByQueryAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws Exception {
+        final String json = "{\"took\":320,\"timed_out\":false,\"total\":100,\"updated\":80,\"created\":0,\"deleted\":0,"
+                + "\"batches\":2,\"version_conflicts\":3,\"noops\":17,\"retries\":{\"bulk\":1,\"search\":0},"
+                + "\"throttled_millis\":0,\"requests_per_second\":-1.0,\"throttled_until_millis\":0,\"failures\":[]}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final BulkByScrollResponse response = action.fromXContent(parser);
+            assertNotNull(response);
+            assertEquals(320L, response.getTook().millis());
+            assertFalse(response.isTimedOut());
+            assertEquals(100L, response.getTotal());
+            assertEquals(80L, response.getUpdated());
+            assertEquals(0L, response.getCreated());
+            assertEquals(0L, response.getDeleted());
+            assertEquals(2, response.getBatches());
+            assertEquals(3L, response.getVersionConflicts());
+            assertEquals(17L, response.getNoops());
+            assertEquals(1L, response.getBulkRetries());
+            assertEquals(0L, response.getSearchRetries());
+            assertEquals(0, response.getBulkFailures().size());
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpUpdateSettingsActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpUpdateSettingsActionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsAction;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+
+class HttpUpdateSettingsActionTest {
+
+    private final HttpUpdateSettingsAction clientAction =
+            new HttpUpdateSettingsAction(ActionTestUtils.testClient(), UpdateSettingsAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptionsAndPreserveExisting() {
+        final UpdateSettingsRequest request = new UpdateSettingsRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertTrue(params.containsKey("expand_wildcards"));
+        assertTrue(params.containsKey("ignore_unavailable"));
+        assertTrue(params.containsKey("allow_no_indices"));
+        assertEquals("false", params.get("preserve_existing"));
+    }
+}


### PR DESCRIPTION
## Summary

Expands OpenSearch `Client` API coverage and fixes several request-parameter serialization bugs in existing actions. All new actions use classes that already ship in the OpenSearch `server` jar, so **no new dependency** is introduced.

## New actions

- **Point-in-Time**: `HttpCreatePitAction`, `HttpDeletePitAction`, `HttpGetAllPitsAction` (`_search/point_in_time`)
- **Reindex / by-query**: `HttpReindexAction`, `HttpUpdateByQueryAction`, `HttpDeleteByQueryAction` (shared `HttpBulkByScrollAction` base parsing `BulkByScrollResponse`)
- **Resolve index**: `HttpResolveIndexAction` (`_resolve/index`)

## Correctness fixes to existing actions

- **`HttpIndexAction`**: forward `if_seq_no` / `if_primary_term` — optimistic-concurrency was silently dropped on the index path (the delete/update paths already forwarded it), plus `require_alias`.
- **`HttpGetAction`**: forward `_source` include/exclude filtering.
- **`HttpBulkAction`**: per-item `retry_on_conflict` on update items, and bulk-level `pipeline` / `routing` / `require_alias`.
- **`HttpMultiSearchAction`**: send `typed_keys=true` so named aggregations/suggesters in sub-searches parse (parity with single search).
- **`HttpSearchAction`, `HttpFieldCapabilitiesAction`, `HttpPutMappingAction`, `HttpGetSettingsAction`, `HttpUpdateSettingsAction`, `HttpExplainAction`**: forward indices options and other previously-dropped parameters (via new shared `HttpAction.appendIndicesOptions` / `expandWildcards` helpers).
- **`wait_for_active_shards`**: `ActiveShardCount.ALL` now serializes to `"all"` instead of `-1` (which the server rejects with HTTP 400); this is applied across all actions that emit the parameter, and the duplicate emission in `HttpClusterHealthAction` is collapsed to a single correct value.

## Testing

- Adds unit tests for the new actions (`fromXContent` response parsing) and for the fixed request-parameter serialization (`ActionTestUtils` builds an inspectable `CurlRequest` so params can be asserted without a live cluster).
- Full unit suite: **285 tests pass** (`mvn test` excluding the Docker/Testcontainers `*ClientTest` integration classes). The container-based integration tests should be run in CI to validate the new actions end-to-end against live engines.
