### PR TITLE
fix(action): forward dropped request params and fix wait_for_active_shards serialization

### DIFF
--- a/src/main/java/org/codelibs/fesen/client/action/HttpCloseIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpCloseIndexAction.java
@@ -29,6 +29,7 @@ import org.opensearch.action.admin.indices.close.CloseIndexResponse;
 import org.opensearch.action.admin.indices.close.CloseIndexResponse.IndexResult;
 import org.opensearch.action.admin.indices.close.CloseIndexResponse.ShardResult;
 import org.opensearch.action.admin.indices.close.CloseIndexResponse.ShardResult.Failure;
+import org.opensearch.action.support.ActiveShardCount;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.xcontent.XContentParser;
@@ -85,6 +86,10 @@ public class HttpCloseIndexAction extends HttpAction {
         if (request.masterNodeTimeout() != null) {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
+        if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
+        }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpDeleteIndexAction.java
@@ -74,6 +74,7 @@ public class HttpDeleteIndexAction extends HttpAction {
         if (request.masterNodeTimeout() != null) {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpFlushAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpFlushAction.java
@@ -70,6 +70,7 @@ public class HttpFlushAction extends HttpAction {
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_flush", request.indices());
         curlRequest.param("wait_if_ongoing", Boolean.toString(request.waitIfOngoing()));
         curlRequest.param("force", Boolean.toString(request.force()));
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
@@ -68,8 +68,9 @@ public class HttpForceMergeAction extends HttpAction {
     protected CurlRequest getCurlRequest(final ForceMergeRequest request) {
         // RestForceMergeAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_forcemerge", request.indices());
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest.param("max_num_segments", String.valueOf(request.maxNumSegments()))
-                .param("only_expunge_deletes", String.valueOf(request.onlyExpungeDeletes()))
-                .param("flush", String.valueOf(request.flush()));
+                .param("only_expunge_deletes", String.valueOf(request.onlyExpungeDeletes())).param("flush", String.valueOf(request.flush()))
+                .param("primary_only", String.valueOf(request.primaryOnly()));
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpForceMergeAction.java
@@ -16,6 +16,7 @@
 package org.codelibs.fesen.client.action;
 
 import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.EngineInfo.EngineType;
 import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeAction;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
@@ -69,8 +70,15 @@ public class HttpForceMergeAction extends HttpAction {
         // RestForceMergeAction
         final CurlRequest curlRequest = client.getCurlRequest(POST, "/_forcemerge", request.indices());
         appendIndicesOptions(curlRequest, request.indicesOptions());
-        return curlRequest.param("max_num_segments", String.valueOf(request.maxNumSegments()))
-                .param("only_expunge_deletes", String.valueOf(request.onlyExpungeDeletes())).param("flush", String.valueOf(request.flush()))
-                .param("primary_only", String.valueOf(request.primaryOnly()));
+        curlRequest.param("max_num_segments", String.valueOf(request.maxNumSegments()))
+                .param("only_expunge_deletes", String.valueOf(request.onlyExpungeDeletes()))
+                .param("flush", String.valueOf(request.flush()));
+        // primary_only is only recognized by OpenSearch 2.x and later; older OpenSearch and
+        // Elasticsearch reject unknown parameters with HTTP 400.
+        final EngineType engineType = client.getEngineInfo().getType();
+        if (engineType == EngineType.OPENSEARCH2 || engineType == EngineType.OPENSEARCH3) {
+            curlRequest.param("primary_only", String.valueOf(request.primaryOnly()));
+        }
+        return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpGetMappingsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpGetMappingsAction.java
@@ -84,6 +84,7 @@ public class HttpGetMappingsAction extends HttpAction {
         if (client.getEngineInfo().getType() != EngineType.ELASTICSEARCH8) {
             curlRequest.param("local", Boolean.toString(request.local()));
         }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 

--- a/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpIndicesAliasesAction.java
@@ -22,11 +22,11 @@ import org.codelibs.fesen.client.HttpClient;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
-import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
@@ -57,30 +57,7 @@ public class HttpIndicesAliasesAction extends HttpAction {
      * @param listener the listener to notify with the response or a failure
      */
     public void execute(final IndicesAliasesRequest request, final ActionListener<AcknowledgedResponse> listener) {
-        String source = null;
-        try (final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startArray("actions")) {
-            for (final AliasActions aliasAction : request.getAliasActions()) {
-                builder.startObject().startObject(aliasAction.actionType().toString().toLowerCase());
-                builder.array("indices", aliasAction.indices());
-                builder.array("aliases", aliasAction.aliases());
-                if (aliasAction.filter() != null) {
-                    builder.field("filter", aliasAction.filter());
-                }
-                if (aliasAction.indexRouting() != null) {
-                    builder.field("index_routing", aliasAction.indexRouting());
-                }
-                if (aliasAction.searchRouting() != null) {
-                    builder.field("search_routing", aliasAction.searchRouting());
-                }
-                builder.endObject().endObject();
-            }
-            builder.endArray().endObject();
-            builder.flush();
-            source = BytesReference.bytes(builder).utf8ToString();
-        } catch (final IOException e) {
-            throw new OpenSearchException("Failed to parse a request.", e);
-        }
-        getCurlRequest(request).body(source).execute(response -> {
+        getCurlRequest(request).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
                 final AcknowledgedResponse indicesAliasesResponse = AcknowledgedResponse.fromXContent(parser);
                 listener.onResponse(indicesAliasesResponse);
@@ -105,6 +82,14 @@ public class HttpIndicesAliasesAction extends HttpAction {
         if (request.masterNodeTimeout() != null) {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
-        return curlRequest;
+        String source = null;
+        try (final XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            request.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            builder.flush();
+            source = BytesReference.bytes(builder).utf8ToString();
+        } catch (final IOException e) {
+            throw new OpenSearchException("Failed to parse a request.", e);
+        }
+        return curlRequest.body(source);
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpOpenIndexAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpOpenIndexAction.java
@@ -76,8 +76,9 @@ public class HttpOpenIndexAction extends HttpAction {
             curlRequest.param("master_timeout", request.masterNodeTimeout().toString());
         }
         if (!ActiveShardCount.DEFAULT.equals(request.waitForActiveShards())) {
-            curlRequest.param("wait_for_active_shards", request.waitForActiveShards().toString());
+            curlRequest.param("wait_for_active_shards", getActiveShardsCountString(request.waitForActiveShards()));
         }
+        appendIndicesOptions(curlRequest, request.indicesOptions());
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpRefreshAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpRefreshAction.java
@@ -66,6 +66,8 @@ public class HttpRefreshAction extends HttpAction {
      * @return the curl request
      */
     protected CurlRequest getCurlRequest(final RefreshRequest request) {
-        return client.getCurlRequest(POST, "/_refresh", request.indices());
+        final CurlRequest curlRequest = client.getCurlRequest(POST, "/_refresh", request.indices());
+        appendIndicesOptions(curlRequest, request.indicesOptions());
+        return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpdateAction.java
@@ -18,7 +18,6 @@ package org.codelibs.fesen.client.action;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
@@ -36,7 +35,6 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.VersionType;
 
 /**
  * Handles the document update API over HTTP for OpenSearch/Elasticsearch.
@@ -124,12 +122,6 @@ public class HttpUpdateAction extends HttpAction {
         curlRequest.param("retry_on_conflict", String.valueOf(request.retryOnConflict()));
         curlRequest.param("if_seq_no", Long.toString(request.ifSeqNo()));
         curlRequest.param("if_primary_term", Long.toString(request.ifPrimaryTerm()));
-        if (request.version() >= 0) {
-            curlRequest.param("version", Long.toString(request.version()));
-        }
-        if (!VersionType.INTERNAL.equals(request.versionType())) {
-            curlRequest.param("version_type", request.versionType().name().toLowerCase(Locale.ROOT));
-        }
         return curlRequest;
     }
 }

--- a/src/test/java/org/codelibs/fesen/client/action/ActionTestUtils.java
+++ b/src/test/java/org/codelibs/fesen/client/action/ActionTestUtils.java
@@ -22,9 +22,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.codelibs.curl.CurlRequest;
+import org.codelibs.fesen.client.EngineInfo;
+import org.codelibs.fesen.client.EngineInfo.EngineType;
 import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.HttpClient.ContentType;
 import org.opensearch.common.settings.Settings;
@@ -39,28 +42,35 @@ import org.opensearch.common.settings.Settings;
  */
 final class ActionTestUtils {
 
-    private static volatile HttpClient client;
+    private static final Map<EngineType, HttpClient> CLIENTS = new ConcurrentHashMap<>();
 
     private ActionTestUtils() {
     }
 
     /**
      * Returns a shared {@link HttpClient} that builds plain, inspectable curl requests.
+     * The backend engine is reported as OpenSearch 3.x.
      *
      * @return the test HTTP client
      */
     static HttpClient testClient() {
-        if (client == null) {
-            synchronized (ActionTestUtils.class) {
-                if (client == null) {
-                    client = createClient();
-                }
-            }
-        }
-        return client;
+        return testClient(EngineType.OPENSEARCH3);
     }
 
-    private static HttpClient createClient() {
+    /**
+     * Returns a shared {@link HttpClient} that builds plain, inspectable curl requests and
+     * reports the given backend engine type from {@link HttpClient#getEngineInfo()}, so that
+     * version-conditional parameter serialization can be exercised offline.
+     *
+     * @param engineType the backend engine type to report
+     * @return the test HTTP client
+     */
+    static HttpClient testClient(final EngineType engineType) {
+        return CLIENTS.computeIfAbsent(engineType, ActionTestUtils::createClient);
+    }
+
+    private static HttpClient createClient(final EngineType engineType) {
+        final EngineInfo engineInfo = stubEngineInfo(engineType);
         final Settings settings = Settings.builder().putList("http.hosts", "localhost:9200").build();
         return new HttpClient(settings, null) {
             @Override
@@ -75,7 +85,41 @@ final class ActionTestUtils {
                 }
                 return method.apply(buf.toString());
             }
+
+            @Override
+            public EngineInfo getEngineInfo() {
+                return engineInfo;
+            }
         };
+    }
+
+    private static EngineInfo stubEngineInfo(final EngineType engineType) {
+        final String distribution;
+        final String number;
+        switch (engineType) {
+        case ELASTICSEARCH7:
+            distribution = "elasticsearch";
+            number = "7.17.0";
+            break;
+        case ELASTICSEARCH8:
+            distribution = "elasticsearch";
+            number = "8.11.0";
+            break;
+        case OPENSEARCH1:
+            distribution = "opensearch";
+            number = "1.3.0";
+            break;
+        case OPENSEARCH2:
+            distribution = "opensearch";
+            number = "2.11.0";
+            break;
+        case OPENSEARCH3:
+        default:
+            distribution = "opensearch";
+            number = "3.0.0";
+            break;
+        }
+        return new EngineInfo(Map.of("version", Map.of("number", number, "distribution", distribution)));
     }
 
     /**

--- a/src/test/java/org/codelibs/fesen/client/action/HttpCloseIndexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpCloseIndexActionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.close.CloseIndexAction;
+import org.opensearch.action.admin.indices.close.CloseIndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+
+class HttpCloseIndexActionTest {
+
+    private final HttpCloseIndexAction clientAction = new HttpCloseIndexAction(ActionTestUtils.testClient(), CloseIndexAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_waitForActiveShardsAll() {
+        final CloseIndexRequest request = new CloseIndexRequest("test-index").waitForActiveShards(ActiveShardCount.ALL);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("all", params.get("wait_for_active_shards"));
+    }
+
+    @Test
+    void test_getCurlRequest_waitForActiveShardsDefaultNotSent() {
+        final CloseIndexRequest request = new CloseIndexRequest("test-index").waitForActiveShards(ActiveShardCount.DEFAULT);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertFalse(params.containsKey("wait_for_active_shards"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpDeleteIndexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpDeleteIndexActionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.delete.DeleteIndexAction;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.support.IndicesOptions;
+
+class HttpDeleteIndexActionTest {
+
+    private final HttpDeleteIndexAction action = new HttpDeleteIndexAction(ActionTestUtils.testClient(), DeleteIndexAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptions() {
+        final DeleteIndexRequest request = new DeleteIndexRequest("test-index");
+        request.indicesOptions(IndicesOptions.fromOptions(true, false, false, true));
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals("true", params.get("ignore_unavailable"));
+        assertEquals("false", params.get("allow_no_indices"));
+        assertEquals("closed", params.get("expand_wildcards"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpFlushActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpFlushActionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.flush.FlushAction;
+import org.opensearch.action.admin.indices.flush.FlushRequest;
+import org.opensearch.action.support.IndicesOptions;
+
+class HttpFlushActionTest {
+
+    private final HttpFlushAction action = new HttpFlushAction(ActionTestUtils.testClient(), FlushAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptions() {
+        final FlushRequest request = new FlushRequest("test-index");
+        request.indicesOptions(IndicesOptions.fromOptions(true, false, false, true));
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals("true", params.get("ignore_unavailable"));
+        assertEquals("false", params.get("allow_no_indices"));
+        assertEquals("closed", params.get("expand_wildcards"));
+        // existing flush params still present
+        assertEquals(String.valueOf(request.waitIfOngoing()), params.get("wait_if_ongoing"));
+        assertEquals(String.valueOf(request.force()), params.get("force"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpForceMergeActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpForceMergeActionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeAction;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.opensearch.action.support.IndicesOptions;
+
+class HttpForceMergeActionTest {
+
+    private final HttpForceMergeAction action = new HttpForceMergeAction(ActionTestUtils.testClient(), ForceMergeAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_primaryOnly() {
+        final ForceMergeRequest request = new ForceMergeRequest("test-index").primaryOnly(true);
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals("true", params.get("primary_only"));
+    }
+
+    @Test
+    void test_getCurlRequest_defaultParams() {
+        final ForceMergeRequest request = new ForceMergeRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals(String.valueOf(request.primaryOnly()), params.get("primary_only"));
+        assertEquals(String.valueOf(request.maxNumSegments()), params.get("max_num_segments"));
+        assertEquals(String.valueOf(request.onlyExpungeDeletes()), params.get("only_expunge_deletes"));
+        assertEquals(String.valueOf(request.flush()), params.get("flush"));
+    }
+
+    @Test
+    void test_getCurlRequest_indicesOptions() {
+        final ForceMergeRequest request = new ForceMergeRequest("test-index");
+        request.indicesOptions(IndicesOptions.fromOptions(true, false, false, true));
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals("true", params.get("ignore_unavailable"));
+        assertEquals("false", params.get("allow_no_indices"));
+        assertEquals("closed", params.get("expand_wildcards"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpForceMergeActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpForceMergeActionTest.java
@@ -16,9 +16,11 @@
 package org.codelibs.fesen.client.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Map;
 
+import org.codelibs.fesen.client.EngineInfo.EngineType;
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeAction;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
@@ -33,6 +35,30 @@ class HttpForceMergeActionTest {
         final ForceMergeRequest request = new ForceMergeRequest("test-index").primaryOnly(true);
         final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
         assertEquals("true", params.get("primary_only"));
+    }
+
+    @Test
+    void test_getCurlRequest_primaryOnly_openSearch2() {
+        final HttpForceMergeAction os2Action =
+                new HttpForceMergeAction(ActionTestUtils.testClient(EngineType.OPENSEARCH2), ForceMergeAction.INSTANCE);
+        final ForceMergeRequest request = new ForceMergeRequest("test-index").primaryOnly(true);
+        final Map<String, String> params = ActionTestUtils.params(os2Action.getCurlRequest(request));
+        assertEquals("true", params.get("primary_only"));
+    }
+
+    @Test
+    void test_getCurlRequest_primaryOnly_notSentOnLegacyEngines() {
+        // primary_only is unknown to OpenSearch 1.x and Elasticsearch 7/8, which reject it with HTTP 400.
+        for (final EngineType engineType : new EngineType[] { EngineType.OPENSEARCH1, EngineType.ELASTICSEARCH7,
+                EngineType.ELASTICSEARCH8 }) {
+            final HttpForceMergeAction legacyAction =
+                    new HttpForceMergeAction(ActionTestUtils.testClient(engineType), ForceMergeAction.INSTANCE);
+            final ForceMergeRequest request = new ForceMergeRequest("test-index").primaryOnly(true);
+            final Map<String, String> params = ActionTestUtils.params(legacyAction.getCurlRequest(request));
+            assertFalse(params.containsKey("primary_only"), engineType.toString());
+            // non-version-specific params are still forwarded
+            assertEquals(String.valueOf(request.maxNumSegments()), params.get("max_num_segments"), engineType.toString());
+        }
     }
 
     @Test

--- a/src/test/java/org/codelibs/fesen/client/action/HttpIndicesAliasesActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpIndicesAliasesActionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesAction;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+
+class HttpIndicesAliasesActionTest {
+
+    /**
+     * Builds the request body exactly as the production action does, by driving the
+     * real {@link HttpIndicesAliasesAction#getCurlRequest} and reading the emitted body.
+     */
+    private static String toBody(final IndicesAliasesRequest request) {
+        final HttpIndicesAliasesAction action = new HttpIndicesAliasesAction(ActionTestUtils.testClient(), IndicesAliasesAction.INSTANCE);
+        return action.getCurlRequest(request).body();
+    }
+
+    @Test
+    void test_body_addAction_writeIndexAndHidden() {
+        final IndicesAliasesRequest request = new IndicesAliasesRequest();
+        request.addAliasAction(AliasActions.add().index("test-index").alias("test-alias").writeIndex(true).isHidden(true));
+        final String body = toBody(request);
+        assertTrue(body.contains("\"is_write_index\":true"), body);
+        assertTrue(body.contains("\"is_hidden\":true"), body);
+    }
+
+    @Test
+    void test_body_addAction_routing() {
+        final IndicesAliasesRequest request = new IndicesAliasesRequest();
+        request.addAliasAction(AliasActions.add().index("test-index").alias("test-alias").routing("r1"));
+        final String body = toBody(request);
+        assertTrue(body.contains("\"routing\":\"r1\""), body);
+    }
+
+    @Test
+    void test_body_removeIndex_noBogusAliases() {
+        final IndicesAliasesRequest request = new IndicesAliasesRequest();
+        request.addAliasAction(AliasActions.removeIndex().index("old-index"));
+        final String body = toBody(request);
+        assertTrue(body.contains("remove_index"), body);
+        assertFalse(body.contains("\"aliases\""), body);
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpOpenIndexActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpOpenIndexActionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.open.OpenIndexAction;
+import org.opensearch.action.admin.indices.open.OpenIndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+
+class HttpOpenIndexActionTest {
+
+    private final HttpOpenIndexAction clientAction = new HttpOpenIndexAction(ActionTestUtils.testClient(), OpenIndexAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_waitForActiveShardsAll() {
+        final OpenIndexRequest request = new OpenIndexRequest("test-index").waitForActiveShards(ActiveShardCount.ALL);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("all", params.get("wait_for_active_shards"));
+    }
+
+    @Test
+    void test_getCurlRequest_waitForActiveShardsDefaultNotSent() {
+        final OpenIndexRequest request = new OpenIndexRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertFalse(params.containsKey("wait_for_active_shards"));
+    }
+
+    @Test
+    void test_getCurlRequest_waitForActiveShardsCount() {
+        final OpenIndexRequest request = new OpenIndexRequest("test-index").waitForActiveShards(ActiveShardCount.from(2));
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("2", params.get("wait_for_active_shards"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpRefreshActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpRefreshActionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.refresh.RefreshAction;
+import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.support.IndicesOptions;
+
+class HttpRefreshActionTest {
+
+    private final HttpRefreshAction action = new HttpRefreshAction(ActionTestUtils.testClient(), RefreshAction.INSTANCE);
+
+    @Test
+    void test_getCurlRequest_indicesOptions() {
+        final RefreshRequest request = new RefreshRequest("test-index");
+        request.indicesOptions(IndicesOptions.fromOptions(true, false, false, true));
+        final Map<String, String> params = ActionTestUtils.params(action.getCurlRequest(request));
+        assertEquals("true", params.get("ignore_unavailable"));
+        assertEquals("false", params.get("allow_no_indices"));
+        assertEquals("closed", params.get("expand_wildcards"));
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpUpdateActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpUpdateActionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.update.UpdateAction;
+import org.opensearch.action.update.UpdateRequest;
+
+class HttpUpdateActionTest {
+
+    private final HttpUpdateAction clientAction = new HttpUpdateAction(ActionTestUtils.testClient(), UpdateAction.INSTANCE);
+
+    /**
+     * The {@code _update} REST endpoint (RestUpdateAction) rejects {@code version}/{@code version_type}
+     * with HTTP 400 because internal versioning is illegal for updates (UpdateRequest itself throws
+     * UnsupportedOperationException on its version/versionType setters and always reports MATCH_ANY /
+     * INTERNAL). Concurrency control must go through if_seq_no/if_primary_term instead. This action must
+     * therefore never emit version params.
+     */
+    @Test
+    void test_getCurlRequest_versionParamsNotSent() {
+        final UpdateRequest request = new UpdateRequest("test-index", "1");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertFalse(params.containsKey("version"));
+        assertFalse(params.containsKey("version_type"));
+    }
+
+    @Test
+    void test_getCurlRequest_ifSeqNoAndPrimaryTerm() {
+        final UpdateRequest request = new UpdateRequest("test-index", "1").setIfSeqNo(5L).setIfPrimaryTerm(2L);
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("5", params.get("if_seq_no"));
+        assertEquals("2", params.get("if_primary_term"));
+    }
+}


### PR DESCRIPTION
## Summary

Correctness fixes to existing HTTP actions, continuing the request-parameter
serialization work from #30. Each fix was verified against the corresponding
OpenSearch `Rest*Action`. No new dependencies; no API changes.

## Fixes

- **HttpOpenIndexAction** — `wait_for_active_shards` for `ActiveShardCount.ALL`
  now serializes to `"all"` instead of `"ALL"` (the server rejects the latter
  with HTTP 400). This is the same bug class fixed centrally in #30; this was the
  one remaining call site still using `ActiveShardCount.toString()`. Also forwards
  indices options.
- **HttpCloseIndexAction** — forwards `wait_for_active_shards` and indices
  options, both of which were dropped (close could otherwise return before shards
  were ready).
- **HttpUpdateAction** — removes the `version` / `version_type` params. The
  `_update` endpoint rejects internal versioning (it requires `if_seq_no` /
  `if_primary_term`, already sent), and `UpdateRequest`'s version setters throw
  `UnsupportedOperationException`, so the removed block was unreachable.
- **HttpIndicesAliasesAction** — builds the request body from the request's own
  `toXContent`, so `is_write_index`, `is_hidden`, `must_exist` and `routing` are
  now emitted (a write-index alias was previously not marked as such), and a
  `remove_index` action no longer emits a bogus empty `aliases`.
- **HttpRefreshAction / HttpFlushAction / HttpForceMergeAction /
  HttpDeleteIndexAction / HttpGetMappingsAction** — forward indices options
  (`ignore_unavailable`, `allow_no_indices`, `expand_wildcards`).
- **HttpForceMergeAction** — also forwards `primary_only`.

## Testing

- Adds unit tests asserting the emitted query params / body for each fix, using
  the existing `ActionTestUtils` offline `CurlRequest` inspection.
- Full unit suite: **301 tests pass** (`mvn test` excluding the Docker /
  Testcontainers `*ClientTest` integration classes). The container-based
  integration tests should be run in CI to validate end-to-end.
