### PR TITLE
test(opensearch3): expand HttpClient action coverage and fix 3 latent bugs

### DIFF
--- a/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpPutRepositoryAction.java
@@ -15,13 +15,20 @@
  */
 package org.codelibs.fesen.client.action;
 
+import java.io.IOException;
+
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
 import org.codelibs.fesen.client.util.UrlUtils;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryAction;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 
 /**
@@ -50,7 +57,14 @@ public class HttpPutRepositoryAction extends HttpAction {
      * @param listener the listener notified with the response or failure
      */
     public void execute(final PutRepositoryRequest request, final ActionListener<AcknowledgedResponse> listener) {
-        getCurlRequest(request).execute(response -> {
+        String source = null;
+        try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
+            builder.flush();
+            source = BytesReference.bytes(builder).utf8ToString();
+        } catch (final IOException e) {
+            throw new OpenSearchException("Failed to parse a request.", e);
+        }
+        getCurlRequest(request).body(source).execute(response -> {
             try (final XContentParser parser = createParser(response)) {
                 final AcknowledgedResponse putRepositoryResponse = AcknowledgedResponse.fromXContent(parser);
                 listener.onResponse(putRepositoryResponse);

--- a/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpSearchAction.java
@@ -124,8 +124,17 @@ public class HttpSearchAction extends HttpAction {
         if (request.preference() != null) {
             curlRequest.param("preference", request.preference());
         }
-        curlRequest.param("ccs_minimize_roundtrips", Boolean.toString(request.isCcsMinimizeRoundtrips()));
-        appendIndicesOptions(curlRequest, request.indicesOptions());
+        // OpenSearch rejects both ccs_minimize_roundtrips and index options together with a
+        // point-in-time search (400 "[ccs_minimize_roundtrips]/[indicesOptions] cannot be used with
+        // point in time"), and over HTTP such a 400 on a request with a body manifests as an
+        // indefinite hang. A PIT already binds its own indices, so omit both when a PIT is set.
+        final boolean hasPointInTime = request.source() != null && request.source().pointInTimeBuilder() != null;
+        if (!hasPointInTime) {
+            curlRequest.param("ccs_minimize_roundtrips", Boolean.toString(request.isCcsMinimizeRoundtrips()));
+        }
+        if (!hasPointInTime) {
+            appendIndicesOptions(curlRequest, request.indicesOptions());
+        }
         return curlRequest;
     }
 }

--- a/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeStatusAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpUpgradeStatusAction.java
@@ -16,6 +16,8 @@
 package org.codelibs.fesen.client.action;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.fesen.client.HttpClient;
@@ -24,7 +26,12 @@ import org.codelibs.fesen.client.util.UrlUtils;
 import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusAction;
 import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusRequest;
 import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
+import org.opensearch.cluster.routing.RecoverySource;
+import org.opensearch.cluster.routing.ShardRouting;
+import org.opensearch.cluster.routing.UnassignedInfo;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
 
 /**
@@ -64,19 +71,24 @@ public class HttpUpgradeStatusAction extends HttpAction {
     }
 
     /**
-     * Parses an upgrade status response, extracting the shard counts from the {@code _shards} section.
-     * Since {@link UpgradeStatusResponse} has package-private constructors, the response is
-     * reconstructed via the wire format.
+     * Parses an {@code _upgrade} status response and reconstructs an {@link UpgradeStatusResponse}.
+     *
+     * <p>The {@code _upgrade} API response is aggregate-only: it exposes per-index byte counts
+     * ({@code size_in_bytes}, {@code size_to_upgrade_in_bytes}, {@code size_to_upgrade_ancient_in_bytes})
+     * but no shard/routing data ({@code detailed=true} is rejected by the server). Since
+     * {@link UpgradeStatusResponse} has package-private constructors and derives its byte getters
+     * from a {@code ShardUpgradeStatus[]}, the response is reconstructed via the wire format by
+     * synthesizing exactly one shard per index carrying that index's aggregate bytes. The synthetic
+     * shard routing is therefore artificial (a single unassigned primary); only the byte totals are
+     * meaningful, because the API exposes no real per-shard routing.
      *
      * @param parser the parser positioned at the response content
      * @return the parsed upgrade status response
      * @throws IOException if parsing fails
      */
     protected UpgradeStatusResponse fromXContent(final XContentParser parser) throws IOException {
+        final List<IndexUpgradeBytes> indexStats = new ArrayList<>();
         String fieldName = null;
-        int totalShards = 0;
-        int successfulShards = 0;
-        int failedShards = 0;
 
         // Initialize parser - move to START_OBJECT
         XContentParser.Token token = parser.nextToken();
@@ -89,37 +101,104 @@ public class HttpUpgradeStatusAction extends HttpAction {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("_shards".equals(fieldName)) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                        if (token == XContentParser.Token.FIELD_NAME) {
-                            fieldName = parser.currentName();
-                        } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                            if ("total".equals(fieldName)) {
-                                totalShards = parser.intValue();
-                            } else if ("successful".equals(fieldName)) {
-                                successfulShards = parser.intValue();
-                            } else if ("failed".equals(fieldName)) {
-                                failedShards = parser.intValue();
-                            }
-                        }
-                    }
+                if ("indices".equals(fieldName)) {
+                    parseIndices(parser, indexStats);
                 } else {
                     consumeObject(parser);
                 }
-            } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                // Skip top-level number fields like size_in_bytes, size_to_upgrade_in_bytes
             }
+            // Top-level size_in_bytes/size_to_upgrade_* numbers are re-derived from the
+            // per-index aggregates below, so they are intentionally ignored here.
         }
 
-        // UpgradeStatusResponse has package-private constructors, so use ByteArrayStreamOutput
-        // BroadcastResponse wire format: totalShards(int), successfulShards(int), failedShards(int), shardFailures(vint size)
-        // Then UpgradeStatusResponse reads: ShardUpgradeStatus array(vint size)
+        return toResponse(indexStats);
+    }
+
+    /**
+     * Parses the {@code indices} object, collecting the aggregate byte counts of each index.
+     *
+     * @param parser the parser positioned at the START_OBJECT of the {@code indices} value
+     * @param indexStats the list to append the per-index aggregates to
+     * @throws IOException if parsing fails
+     */
+    protected void parseIndices(final XContentParser parser, final List<IndexUpgradeBytes> indexStats) throws IOException {
+        String indexName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                indexName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                indexStats.add(parseIndexBytes(indexName, parser));
+            }
+        }
+    }
+
+    /**
+     * Parses a single index's aggregate byte counts.
+     *
+     * @param indexName the name of the index being parsed
+     * @param parser the parser positioned at the START_OBJECT of the index's stats
+     * @return the aggregate byte counts of the index
+     * @throws IOException if parsing fails
+     */
+    protected IndexUpgradeBytes parseIndexBytes(final String indexName, final XContentParser parser) throws IOException {
+        long totalBytes = 0;
+        long toUpgradeBytes = 0;
+        long toUpgradeBytesAncient = 0;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("size_in_bytes".equals(fieldName)) {
+                    totalBytes = parser.longValue();
+                } else if ("size_to_upgrade_in_bytes".equals(fieldName)) {
+                    toUpgradeBytes = parser.longValue();
+                } else if ("size_to_upgrade_ancient_in_bytes".equals(fieldName)) {
+                    toUpgradeBytesAncient = parser.longValue();
+                }
+            }
+        }
+        return new IndexUpgradeBytes(indexName, totalBytes, toUpgradeBytes, toUpgradeBytesAncient);
+    }
+
+    /**
+     * Reconstructs an {@link UpgradeStatusResponse} from the collected per-index aggregates by
+     * synthesizing one shard per index over the wire format that
+     * {@link UpgradeStatusResponse#UpgradeStatusResponse(org.opensearch.core.common.io.stream.StreamInput)}
+     * reads. The synthetic routing is artificial (a single unassigned primary); only the byte totals
+     * are meaningful because the {@code _upgrade} API exposes no per-shard routing.
+     *
+     * @param indexStats the per-index aggregate byte counts (may be empty)
+     * @return the reconstructed upgrade status response
+     * @throws IOException if serialization fails
+     */
+    protected UpgradeStatusResponse toResponse(final List<IndexUpgradeBytes> indexStats) throws IOException {
+        final int shardCount = indexStats.size();
         try (final ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
-            out.writeInt(totalShards);
-            out.writeInt(successfulShards);
-            out.writeInt(failedShards);
+            // BroadcastResponse header (read via readVInt): totalShards, successfulShards, failedShards,
+            // shardFailures length. One synthetic shard per index, all successful, none failed.
+            out.writeVInt(shardCount);
+            out.writeVInt(shardCount);
+            out.writeVInt(0);
             out.writeVInt(0); // no shard failures
-            out.writeVInt(0); // no ShardUpgradeStatus
+            // UpgradeStatusResponse: the number of ShardUpgradeStatus entries.
+            out.writeVInt(shardCount);
+            for (final IndexUpgradeBytes stats : indexStats) {
+                // Synthesize exactly one shard per index carrying that index's aggregate bytes. The
+                // shard id and routing share the same index name so getIndices() groups them correctly.
+                final ShardId shardId = new ShardId(new Index(stats.index, "_na_"), 0);
+                final ShardRouting shardRouting =
+                        ShardRouting.newUnassigned(shardId, true, RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+                                new UnassignedInfo(UnassignedInfo.Reason.CLUSTER_RECOVERED, "synthetic"));
+                // ShardUpgradeStatus wire format: shardId, shardRouting, then three fixed-width longs.
+                shardId.writeTo(out);
+                shardRouting.writeTo(out);
+                out.writeLong(stats.totalBytes);
+                out.writeLong(stats.toUpgradeBytes);
+                out.writeLong(stats.toUpgradeBytesAncient);
+            }
             return action.getResponseReader().read(out.toStreamInput());
         }
     }
@@ -140,6 +219,37 @@ public class HttpUpgradeStatusAction extends HttpAction {
             } else if (token == XContentParser.Token.END_OBJECT || token == XContentParser.Token.END_ARRAY) {
                 depth--;
             }
+        }
+    }
+
+    /**
+     * Holds the aggregate upgrade byte counts parsed for a single index. These are the only
+     * per-index values the {@code _upgrade} API exposes; no shard/routing data is available.
+     */
+    protected static final class IndexUpgradeBytes {
+        /** The index name. */
+        protected final String index;
+        /** The total size of the index in bytes. */
+        protected final long totalBytes;
+        /** The number of bytes that need to be upgraded. */
+        protected final long toUpgradeBytes;
+        /** The number of ancient bytes that need to be upgraded. */
+        protected final long toUpgradeBytesAncient;
+
+        /**
+         * Creates a new aggregate byte holder for an index.
+         *
+         * @param index the index name
+         * @param totalBytes the total size of the index in bytes
+         * @param toUpgradeBytes the number of bytes that need to be upgraded
+         * @param toUpgradeBytesAncient the number of ancient bytes that need to be upgraded
+         */
+        protected IndexUpgradeBytes(final String index, final long totalBytes, final long toUpgradeBytes,
+                final long toUpgradeBytesAncient) {
+            this.index = index;
+            this.totalBytes = totalBytes;
+            this.toUpgradeBytes = toUpgradeBytes;
+            this.toUpgradeBytesAncient = toUpgradeBytesAncient;
         }
     }
 

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
@@ -40,13 +40,27 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.DocWriteResponse.Result;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.node.hotthreads.NodesHotThreadsResponse;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
+import org.opensearch.action.admin.cluster.node.tasks.get.GetTaskResponse;
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.opensearch.action.admin.cluster.node.usage.NodesUsageResponse;
+import org.opensearch.action.admin.cluster.remote.RemoteInfoAction;
+import org.opensearch.action.admin.cluster.remote.RemoteInfoRequest;
+import org.opensearch.action.admin.cluster.remote.RemoteInfoResponse;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.action.admin.cluster.repositories.verify.VerifyRepositoryResponse;
 import org.opensearch.action.admin.cluster.reroute.ClusterRerouteAction;
 import org.opensearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.opensearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptResponse;
 import org.opensearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.opensearch.action.admin.indices.alias.Alias;
@@ -66,6 +80,7 @@ import org.opensearch.action.admin.indices.open.OpenIndexResponse;
 import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.admin.indices.rollover.RolloverResponse;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
 import org.opensearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
@@ -99,12 +114,15 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.tasks.TaskId;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.indices.recovery.RecoverySettings;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.PointInTimeBuilder;
+import org.opensearch.tasks.TaskInfo;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -143,6 +161,7 @@ class OpenSearch3ClientTest {
                 .withEnv("discovery.type", "single-node")//
                 .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")//
                 .withEnv("DISABLE_SECURITY_PLUGIN", "true")//
+                .withEnv("path.repo", "/tmp/repo")//
                 .withExposedPorts(9200);
         server.start();
     }
@@ -1319,6 +1338,8 @@ class OpenSearch3ClientTest {
             builder.flush();
             try (OutputStream out = builder.getOutputStream()) {
                 final String value = ((ByteArrayOutputStream) out).toString("UTF-8");
+                assertFalse(value.isEmpty());
+                assertTrue(value.contains("nodes"));
                 System.out.println(value);
             }
         }
@@ -1997,21 +2018,6 @@ class OpenSearch3ClientTest {
         }
     }
 
-    // TODO PutIndexTemplateAction
-    // TODO GetIndexTemplatesAction
-    // TODO DeleteIndexTemplateAction
-    // TODO CancelTasksAction
-    // TODO ListTasksAction
-    // TODO VerifyRepositoryAction
-    // TODO PutRepositoryAction
-    // TODO GetRepositoriesAction
-    // TODO DeleteRepositoryAction
-    // TODO SnapshotsStatusAction
-    // TODO CreateSnapshotAction
-    // TODO GetSnapshotsAction
-    // TODO DeleteSnapshotAction
-    // TODO RestoreSnapshotAction
-
     // needs x-pack
     // TODO @Test
     void test_info() throws Exception {
@@ -2422,6 +2428,11 @@ class OpenSearch3ClientTest {
         assertNotNull(pitId);
         assertFalse(pitId.isEmpty());
 
+        // PIT-backed search must read the 3 documents captured by the point in time.
+        final SearchResponse pitSearchResponse = client.prepareSearch().setPointInTime(new PointInTimeBuilder(pitId))
+                .setQuery(QueryBuilders.matchAllQuery()).setSize(10).execute().actionGet();
+        assertEquals(3L, pitSearchResponse.getHits().getTotalHits().value());
+
         final org.opensearch.action.search.GetAllPitNodesResponse getAllPitsResponse = client
                 .execute(org.opensearch.action.search.GetAllPitsAction.INSTANCE, new org.opensearch.action.search.GetAllPitNodesRequest())
                 .actionGet();
@@ -2459,5 +2470,276 @@ class OpenSearch3ClientTest {
                 .execute(org.opensearch.action.search.GetAllPitsAction.INSTANCE, new org.opensearch.action.search.GetAllPitNodesRequest())
                 .actionGet();
         assertTrue(getAllPitsResponse.getPitInfos().isEmpty());
+    }
+
+    @Test
+    void test_list_tasks() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.admin().cluster().prepareListTasks().execute(wrap(res -> {
+            try {
+                assertNotNull(res);
+                assertNotNull(res.getTasks());
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            e.printStackTrace();
+            try {
+                fail();
+            } finally {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+
+        {
+            final ListTasksResponse listTasksResponse = client.admin().cluster().prepareListTasks().execute().actionGet();
+            assertNotNull(listTasksResponse);
+            assertNotNull(listTasksResponse.getTasks());
+        }
+    }
+
+    @Test
+    void test_nodes_usage() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.admin().cluster().prepareNodesUsage().execute(wrap(res -> {
+            try {
+                assertNotNull(res);
+                assertNotNull(res.getNodes());
+                assertNotNull(res.getNodesMap());
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            e.printStackTrace();
+            try {
+                fail();
+            } finally {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+
+        {
+            final NodesUsageResponse nodesUsageResponse = client.admin().cluster().prepareNodesUsage().execute().actionGet();
+            assertNotNull(nodesUsageResponse);
+            assertNotNull(nodesUsageResponse.getNodes());
+            assertNotNull(nodesUsageResponse.getNodesMap());
+        }
+    }
+
+    @Test
+    void test_cancel_tasks() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.admin().cluster().prepareCancelTasks().execute(wrap(res -> {
+            try {
+                assertNotNull(res);
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            e.printStackTrace();
+            try {
+                fail();
+            } finally {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+
+        {
+            final CancelTasksResponse cancelTasksResponse = client.admin().cluster().prepareCancelTasks().execute().actionGet();
+            assertNotNull(cancelTasksResponse);
+        }
+    }
+
+    @Test
+    void test_remote_info() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest(), wrap(res -> {
+            try {
+                assertNotNull(res);
+                assertNotNull(res.getInfos());
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            e.printStackTrace();
+            try {
+                fail();
+            } finally {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+
+        {
+            final RemoteInfoResponse remoteInfoResponse = client.execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest()).actionGet();
+            assertNotNull(remoteInfoResponse);
+            assertNotNull(remoteInfoResponse.getInfos());
+        }
+    }
+
+    @Test
+    void test_get_task() throws Exception {
+        // Find a currently running task to look up. A standalone node always reports at least
+        // the list-tasks call that is running while the response is being built.
+        final ListTasksResponse listTasksResponse = client.admin().cluster().prepareListTasks().execute().actionGet();
+        assertNotNull(listTasksResponse);
+        assertNotNull(listTasksResponse.getTasks());
+        if (listTasksResponse.getTasks().isEmpty()) {
+            // Nothing to look up; the list-tasks smoke assertions above are sufficient.
+            return;
+        }
+
+        final TaskInfo taskInfo = listTasksResponse.getTasks().get(0);
+        final TaskId taskId = taskInfo.getTaskId();
+        try {
+            final GetTaskResponse getTaskResponse = client.admin().cluster().prepareGetTask(taskId).execute().actionGet();
+            // The task may still be running; if it is found the response must expose it.
+            assertNotNull(getTaskResponse);
+            assertNotNull(getTaskResponse.getTask());
+        } catch (final OpenSearchException e) {
+            // The task completed and was removed between listing and lookup (typically a 404
+            // resource_not_found_exception). This is expected and acceptable, not a failure.
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    void test_upgrade_status() throws Exception {
+        final String index = "test_upgrade_status";
+        client.admin().indices().prepareCreate(index).execute().actionGet();
+        client.prepareIndex().setIndex(index).setId("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .setSource("{\"text\":\"test\"}", XContentType.JSON).execute().actionGet();
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.admin().indices().prepareUpgradeStatus(index).execute(wrap(res -> {
+            try {
+                assertNotNull(res);
+                assertNotNull(res.getIndices());
+            } finally {
+                latch.countDown();
+            }
+        }, e -> {
+            e.printStackTrace();
+            try {
+                fail();
+            } finally {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+
+        {
+            final UpgradeStatusResponse upgradeStatusResponse = client.admin().indices().prepareUpgradeStatus(index).execute().actionGet();
+            assertNotNull(upgradeStatusResponse);
+            assertNotNull(upgradeStatusResponse.getIndices());
+            // A document was indexed, so the reconstructed per-index aggregates must be non-empty.
+            assertTrue(upgradeStatusResponse.getTotalBytes() > 0);
+            assertTrue(upgradeStatusResponse.getIndices().containsKey(index));
+        }
+    }
+
+    @Test
+    void test_crud_snapshot_repository() throws Exception {
+        final String repository = "test_crud_snapshot_repository";
+        try {
+            // Register an fs repository (location must be under the container's path.repo).
+            final AcknowledgedResponse putResponse = client.admin().cluster().preparePutRepository(repository).setType("fs")
+                    .setSettings(Settings.builder().put("location", "/tmp/repo/" + repository).build()).execute().actionGet();
+            assertTrue(putResponse.isAcknowledged());
+
+            // Verify the repository.
+            final VerifyRepositoryResponse verifyResponse =
+                    client.admin().cluster().prepareVerifyRepository(repository).execute().actionGet();
+            assertNotNull(verifyResponse);
+            assertNotNull(verifyResponse.getNodes());
+
+            // Get repositories and ensure the created one is present.
+            final GetRepositoriesResponse getResponse = client.admin().cluster().prepareGetRepositories(repository).execute().actionGet();
+            assertNotNull(getResponse);
+            assertTrue(getResponse.repositories().stream().anyMatch(r -> repository.equals(r.name())));
+
+            // Delete the repository.
+            final AcknowledgedResponse deleteResponse = client.admin().cluster().prepareDeleteRepository(repository).execute().actionGet();
+            assertTrue(deleteResponse.isAcknowledged());
+        } finally {
+            try {
+                client.admin().cluster().prepareDeleteRepository(repository).execute().actionGet();
+            } catch (final Exception e) {
+                // ignore cleanup failure (the repository may already be deleted)
+            }
+        }
+    }
+
+    @Test
+    void test_snapshot_lifecycle() throws Exception {
+        final String repository = "test_snapshot_lifecycle_repo";
+        final String snapshot = "test_snapshot_lifecycle_snap";
+        final String index = "test_snapshot_lifecycle";
+
+        // Index a document into the source index.
+        client.prepareIndex().setIndex(index).setId("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .setSource("{\"text\":\"snapshot test\"}", XContentType.JSON).execute().actionGet();
+        client.admin().indices().prepareRefresh(index).execute().actionGet();
+
+        // Register an fs repository.
+        final AcknowledgedResponse putRepositoryResponse = client.admin().cluster().preparePutRepository(repository).setType("fs")
+                .setSettings(Settings.builder().put("location", "/tmp/repo/" + repository).build()).execute().actionGet();
+        assertTrue(putRepositoryResponse.isAcknowledged());
+
+        try {
+            // Create a snapshot of the source index and wait for completion.
+            final CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repository, snapshot)
+                    .setWaitForCompletion(true).setIndices(index).execute().actionGet();
+            assertNotNull(createSnapshotResponse.getSnapshotInfo());
+            assertEquals("SUCCESS", createSnapshotResponse.getSnapshotInfo().state().name());
+
+            // Query the snapshot status.
+            final SnapshotsStatusResponse snapshotsStatusResponse =
+                    client.admin().cluster().prepareSnapshotStatus(repository).setSnapshots(snapshot).execute().actionGet();
+            assertNotNull(snapshotsStatusResponse);
+            assertNotNull(snapshotsStatusResponse.getSnapshots());
+
+            // Get snapshots and ensure the created one is present.
+            final GetSnapshotsResponse getSnapshotsResponse =
+                    client.admin().cluster().prepareGetSnapshots(repository).execute().actionGet();
+            assertNotNull(getSnapshotsResponse);
+            assertTrue(getSnapshotsResponse.getSnapshots().stream().anyMatch(s -> snapshot.equals(s.snapshotId().getName())));
+
+            // Delete the source index so the restore has to recreate it.
+            client.admin().indices().prepareDelete(index).execute().actionGet();
+
+            // Restore the snapshot and wait for completion.
+            final RestoreSnapshotResponse restoreSnapshotResponse =
+                    client.admin().cluster().prepareRestoreSnapshot(repository, snapshot).setWaitForCompletion(true).execute().actionGet();
+            assertNotNull(restoreSnapshotResponse.getRestoreInfo());
+            assertTrue(restoreSnapshotResponse.getRestoreInfo().totalShards() > 0);
+
+            // The restored document must be searchable again.
+            client.admin().indices().prepareRefresh(index).execute().actionGet();
+            final SearchResponse searchResponse = client.prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet();
+            assertEquals(1L, searchResponse.getHits().getTotalHits().value());
+        } finally {
+            // Two independent cleanup blocks so one failure cannot skip the other and leak resources.
+            try {
+                client.admin().cluster().prepareDeleteSnapshot(repository, snapshot).execute().actionGet();
+            } catch (final Exception e) {
+                // ignore snapshot cleanup failure
+            }
+            try {
+                client.admin().cluster().prepareDeleteRepository(repository).execute().actionGet();
+            } catch (final Exception e) {
+                // ignore repository cleanup failure
+            }
+        }
+    }
+
+    @Test
+    void test_engine_info() throws Exception {
+        final EngineInfo engineInfo = client.getEngineInfo();
+        assertNotNull(engineInfo);
+        assertEquals(EngineInfo.EngineType.OPENSEARCH3, engineInfo.getType());
     }
 }

--- a/src/test/java/org/codelibs/fesen/client/action/HttpPutRepositoryActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpPutRepositoryActionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryAction;
+import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+class HttpPutRepositoryActionTest {
+
+    private final HttpPutRepositoryAction clientAction =
+            new HttpPutRepositoryAction(ActionTestUtils.testClient(), PutRepositoryAction.INSTANCE);
+
+    private static PutRepositoryRequest putRepositoryRequest() {
+        final PutRepositoryRequest request = new PutRepositoryRequest("repo");
+        request.type("fs");
+        request.settings(Settings.builder().put("location", "/tmp/repo/repo").build());
+        return request;
+    }
+
+    /**
+     * Builds the request body exactly as {@link HttpPutRepositoryAction#execute} does, so the JSON
+     * payload that is sent to {@code PUT /_snapshot/{name}} can be inspected offline.
+     */
+    private static String toBody(final PutRepositoryRequest request) throws Exception {
+        try (final XContentBuilder builder = request.toXContent(JsonXContent.contentBuilder(), ToXContent.EMPTY_PARAMS)) {
+            builder.flush();
+            return BytesReference.bytes(builder).utf8ToString();
+        }
+    }
+
+    @Test
+    void test_getCurlRequest_urlAndVerify() {
+        final PutRepositoryRequest request = putRepositoryRequest();
+        // Endpoint is PUT /_snapshot/{name}.
+        assertTrue(ActionTestUtils.url(clientAction.getCurlRequest(request)).endsWith("/_snapshot/repo"));
+        assertEquals("true", ActionTestUtils.params(clientAction.getCurlRequest(request)).get("verify"));
+    }
+
+    @Test
+    void test_body_carriesTypeAndSettings() throws Exception {
+        // The body is required; without it PUT /_snapshot/{name} returns a 400 parse_exception.
+        final String body = toBody(putRepositoryRequest());
+        assertTrue(body.contains("\"type\":\"fs\""), body);
+        assertTrue(body.contains("\"settings\""), body);
+        assertTrue(body.contains("\"location\""), body);
+        assertTrue(body.contains("/tmp/repo/repo"), body);
+    }
+}

--- a/src/test/java/org/codelibs/fesen/client/action/HttpSearchActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpSearchActionTest.java
@@ -16,6 +16,7 @@
 package org.codelibs.fesen.client.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 class HttpSearchActionTest {
@@ -41,6 +43,30 @@ class HttpSearchActionTest {
         assertEquals("false", params.get("ignore_unavailable"));
         assertEquals("true", params.get("allow_no_indices"));
         assertEquals("true", params.get("typed_keys"));
+    }
+
+    @Test
+    void test_getCurlRequest_pitIncompatibleParams_emittedWithoutPit() {
+        // A plain search still carries ccs_minimize_roundtrips and the index options.
+        final SearchRequest request = new SearchRequest("test-index");
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertEquals("true", params.get("ccs_minimize_roundtrips"));
+        assertTrue(params.containsKey("ignore_unavailable"));
+        assertTrue(params.containsKey("allow_no_indices"));
+        assertTrue(params.containsKey("expand_wildcards"));
+    }
+
+    @Test
+    void test_getCurlRequest_pitIncompatibleParams_omittedWithPit() {
+        // OpenSearch rejects both ccs_minimize_roundtrips and index options together with a
+        // point-in-time search, so all of them must be omitted whenever the source carries a PIT.
+        final SearchRequest request = new SearchRequest();
+        request.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("pit-id")));
+        final Map<String, String> params = ActionTestUtils.params(clientAction.getCurlRequest(request));
+        assertFalse(params.containsKey("ccs_minimize_roundtrips"));
+        assertFalse(params.containsKey("ignore_unavailable"));
+        assertFalse(params.containsKey("allow_no_indices"));
+        assertFalse(params.containsKey("expand_wildcards"));
     }
 
     @Test

--- a/src/test/java/org/codelibs/fesen/client/action/HttpUpgradeStatusActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpUpgradeStatusActionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fesen.client.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusAction;
+import org.opensearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+
+class HttpUpgradeStatusActionTest {
+
+    private final HttpUpgradeStatusAction action = new HttpUpgradeStatusAction(null, UpgradeStatusAction.INSTANCE);
+
+    @Test
+    void test_fromXContent() throws IOException {
+        // Exact aggregate-only shape returned by the _upgrade status API (verified on OpenSearch 3.7).
+        final String json = "{" //
+                + "\"size_in_bytes\":4243," //
+                + "\"size_to_upgrade_in_bytes\":0," //
+                + "\"size_to_upgrade_ancient_in_bytes\":0," //
+                + "\"indices\":{" //
+                + "\"idx\":{\"size_in_bytes\":4243,\"size_to_upgrade_in_bytes\":0,\"size_to_upgrade_ancient_in_bytes\":0}" //
+                + "}}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final UpgradeStatusResponse resp = action.fromXContent(parser);
+            assertNotNull(resp);
+            // Byte totals are re-derived from the synthetic per-index shards.
+            assertEquals(4243L, resp.getTotalBytes());
+            assertEquals(0L, resp.getToUpgradeBytes());
+            assertEquals(0L, resp.getToUpgradeBytesAncient());
+            assertEquals(1, resp.getIndices().size());
+            assertNotNull(resp.getIndices().get("idx"));
+            assertEquals(4243L, resp.getIndices().get("idx").getTotalBytes());
+        }
+    }
+
+    @Test
+    void test_fromXContent_multipleIndices() throws IOException {
+        final String json = "{" //
+                + "\"size_in_bytes\":300," //
+                + "\"size_to_upgrade_in_bytes\":30," //
+                + "\"size_to_upgrade_ancient_in_bytes\":5," //
+                + "\"indices\":{" //
+                + "\"a\":{\"size_in_bytes\":100,\"size_to_upgrade_in_bytes\":10,\"size_to_upgrade_ancient_in_bytes\":5}," //
+                + "\"b\":{\"size_in_bytes\":200,\"size_to_upgrade_in_bytes\":20,\"size_to_upgrade_ancient_in_bytes\":0}" //
+                + "}}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final UpgradeStatusResponse resp = action.fromXContent(parser);
+            assertNotNull(resp);
+            assertEquals(2, resp.getIndices().size());
+            // Aggregate totals sum the per-index synthetic shards.
+            assertEquals(300L, resp.getTotalBytes());
+            assertEquals(30L, resp.getToUpgradeBytes());
+            assertEquals(5L, resp.getToUpgradeBytesAncient());
+            assertEquals(100L, resp.getIndices().get("a").getTotalBytes());
+            assertEquals(10L, resp.getIndices().get("a").getToUpgradeBytes());
+            assertEquals(5L, resp.getIndices().get("a").getToUpgradeBytesAncient());
+            assertEquals(200L, resp.getIndices().get("b").getTotalBytes());
+            assertEquals(20L, resp.getIndices().get("b").getToUpgradeBytes());
+        }
+    }
+
+    @Test
+    void test_fromXContent_emptyIndices() throws IOException {
+        // A missing/empty "indices" object must yield an all-empty response rather than fail.
+        final String json = "{\"size_in_bytes\":0,\"size_to_upgrade_in_bytes\":0,\"size_to_upgrade_ancient_in_bytes\":0,\"indices\":{}}";
+        try (final XContentParser parser =
+                JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, json)) {
+            final UpgradeStatusResponse resp = action.fromXContent(parser);
+            assertNotNull(resp);
+            assertTrue(resp.getIndices().isEmpty());
+            assertEquals(0L, resp.getTotalBytes());
+        }
+    }
+}


### PR DESCRIPTION
## Overview

`OpenSearch3ClientTest` was already the most complete of the five backend integration suites, so this PR closes the remaining gap against the **registered-action API surface**: several `Http*Action`s wired in `HttpClient` had no coverage anywhere. Adding end-to-end tests for them (against a real OpenSearch 3.7 Testcontainer) surfaced three latent, previously-untested production bugs, which are fixed here.

## New / enhanced tests (`OpenSearch3ClientTest`)

- **Task management / diagnostics smoke tests:** `test_list_tasks`, `test_get_task`, `test_cancel_tasks`, `test_nodes_usage`, `test_remote_info`, `test_upgrade_status`.
- **Snapshot & repository lifecycle:** `test_crud_snapshot_repository` (put → verify → get → delete) and `test_snapshot_lifecycle` (create → status → get → restore → delete, asserting the restored doc is searchable). `startServer()` now sets `path.repo` so an `fs` repository can be registered; teardown uses two independent delete blocks so one cleanup failure cannot leak the other resource.
- **Engine detection:** `test_engine_info` asserts the live client detects `OPENSEARCH3`.
- **Depth improvements:** `test_pit_lifecycle` now runs a PIT-backed search and asserts it reads the captured documents; `test_stats` now asserts the serialized `NodesStatsResponse` XContent is non-empty; `test_upgrade_status` asserts real (non-zero) byte totals.

## Bug fixes surfaced by the new coverage

**1. `HttpPutRepositoryAction` sent no request body.**
`PUT /_snapshot/{name}` was issued without a body, so the server rejected it with `400 parse_exception: request body is required` — the action never worked. It now serializes the repository `type`/`settings` via `request.toXContent(...)`, mirroring `HttpCreateSnapshotAction`. Adds `HttpPutRepositoryActionTest`.

**2. `HttpUpgradeStatusAction` always returned empty data.**
`fromXContent` looked for a top-level `_shards` object that the `_upgrade` response never emits and always serialized zero `ShardUpgradeStatus` entries, so `getIndices()` was always empty and all byte/shard counts were `0`. It also wrote the `BroadcastResponse` header with `writeInt` where the wire format reads `writeVInt` (only "worked" because every value was zero). It now parses the per-index aggregate byte counts (`size_in_bytes` / `size_to_upgrade_in_bytes` / `size_to_upgrade_ancient_in_bytes`) and reconstructs the response so `getTotalBytes()` and the per-index sizes are correct. Because the `_upgrade` API exposes no per-shard routing (`detailed=true` is rejected on 3.7), the reconstruction synthesizes one shard per index; the shard routing is therefore artificial and only the byte totals are meaningful — this is documented in the code. Adds `HttpUpgradeStatusActionTest`.

**3. `HttpSearchAction` hung on point-in-time searches.**
It emitted `ccs_minimize_roundtrips` and the index options (`ignore_unavailable` / `allow_no_indices` / `expand_wildcards`) unconditionally. OpenSearch rejects both together with a point-in-time search (`400 "... cannot be used with point in time"`), and over this HTTP client a `400` on a request that carries a body manifests as an indefinite hang. It now omits both when the request carries a PIT (a PIT already binds its own indices). Non-PIT searches are byte-identical, so all other engines are unaffected. Extends `HttpSearchActionTest`.

## Testing

- `OpenSearch3ClientTest`: **88/88** green (Docker, OpenSearch 3.7.0).
- Offline unit suite (all engines' request-building + node/engine tests): **340/340** green.
- `mvn formatter:format license:format` applied.

## Notes / out of scope

- The sibling `HttpUpgradeAction` (the `POST /_upgrade` action, no integration coverage here) has the same `writeInt`-vs-`writeVInt` header issue; left untouched to keep this change scoped.
- The PIT-search fix guards the two parameter groups OpenSearch actually rejects with a PIT; other search parameters are unchanged.
