### PR TITLE
test(opensearch1): skip demo security config install in OpenSearch1ClientTest

### DIFF
--- a/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch1ClientTest.java
@@ -142,7 +142,8 @@ class OpenSearch1ClientTest {
     static void startServer() {
         server = new GenericContainer<>(DockerImageName.parse(imageTag))//
                 .withEnv("discovery.type", "single-node")//
-                .withEnv("plugins.security.disabled", "true")//
+                .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")//
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true")//
                 .withExposedPorts(9200);
         server.start();
     }


### PR DESCRIPTION
## Summary
- `OpenSearch1ClientTest` was the only Testcontainers-based test class still running the OpenSearch security plugin's demo config installer at container startup (`plugins.security.disabled=true`), while `OpenSearch2ClientTest`/`OpenSearch3ClientTest` already skip it via `DISABLE_INSTALL_DEMO_CONFIG=true` + `DISABLE_SECURITY_PLUGIN=true`.
- This left `OpenSearch1ClientTest` as the one class hitting the container startup wait-strategy timeout in CI, since it alone performs the extra demo-config install step during container boot.
- Aligns `OpenSearch1ClientTest` with the already-proven pattern used by the other four Docker-backed client tests, removing the difference between the failing and passing test classes.

## Test plan
- [x] `mvn -Dtest=OpenSearch1ClientTest test` — 41/41 tests pass
- [x] `mvn test` (full suite, all Docker-backed classes included) — all green
- [x] `mvn formatter:format license:format` — no additional changes needed