### PR TITLE
docs: rewrite README for open-source clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,28 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fesen.client/fesen-httpclient/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fesen.client/fesen-httpclient)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-A high-performance HTTP-based client implementation for OpenSearch and Elasticsearch that provides the standard `org.opensearch.client.Client` interface over HTTP REST APIs. This client enables seamless integration with OpenSearch/Elasticsearch clusters while maintaining full API compatibility.
+Fesen HttpClient is a Java implementation of the `org.opensearch.client.Client` interface that talks to OpenSearch or Elasticsearch over their HTTP REST APIs instead of the native transport protocol. It lets applications written against the standard OpenSearch client API run against any HTTP-reachable cluster, including managed services that only expose REST endpoints.
 
-## 🚀 Key Features
+The library is built on [curl4j](https://github.com/codelibs/curl4j), a lightweight, pure-Java HTTP client, so it has no dependency on the OpenSearch/Elasticsearch transport module.
 
-- **Universal Compatibility**: Supports Elasticsearch 7.x, 8.x and OpenSearch 1.x, 2.x, 3.x
-- **Standard Interface**: Implements the familiar `org.opensearch.client.Client` interface
-- **High Performance**: Built on curl4j library for efficient HTTP communication
-- **Production Ready**: Includes connection pooling, failover, health checking, and load balancing
-- **Comprehensive Security**: SSL/TLS support, authentication, and proxy configuration
-- **Asynchronous Operations**: Full async support with ActionListener callbacks
-- **Extensive API Coverage**: Support for all major OpenSearch/Elasticsearch operations
+## Features
 
-## 📋 Prerequisites
+- Implements `org.opensearch.client.Client`, so existing code written against that interface can switch transports with minimal changes.
+- Works against Elasticsearch 7.x and 8.x, and OpenSearch 1.x, 2.x, and 3.x. See [Supported Engines](#supported-engines) for the exact versions covered by the test suite.
+- Detects the backend engine and version automatically from the cluster's root endpoint response.
+- Supports multiple nodes with health checking and failover.
+- Supports HTTP Basic authentication, TLS, and HTTP proxies.
+- Covers most administrative and data APIs: documents, search, bulk, scroll, point-in-time, index and template management, cluster and node APIs, snapshots, ingest pipelines, and more.
 
-- **Java**: 17 or higher
-- **Maven**: 3.6.0 or higher
-- **OpenSearch/Elasticsearch**: Compatible with ES 7.x, 8.x and OpenSearch 1.x, 2.x, 3.x
+## Requirements
 
-## 🛠 Installation
+- Java 17 or higher
+- Maven 3.6.0 or higher (for building from source)
+- Docker (only needed to run the integration test suite)
 
-### Maven Dependency
+## Installation
 
-Add the following dependency to your `pom.xml`:
+### Maven
 
 ```xml
 <dependency>
@@ -36,17 +35,15 @@ Add the following dependency to your `pom.xml`:
 </dependency>
 ```
 
-### Gradle Dependency
-
-Add to your `build.gradle`:
+### Gradle
 
 ```gradle
 implementation 'org.codelibs.fesen.client:fesen-httpclient:3.7.0'
 ```
 
-## 🏃 Quick Start
+Check the Maven Central badge above for the latest published version.
 
-### Basic Usage
+## Quick Start
 
 ```java
 import org.opensearch.client.Client;
@@ -55,7 +52,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.QueryBuilders;
 import static org.opensearch.core.action.ActionListener.wrap;
 
-// Create client with basic configuration
 Settings settings = Settings.builder()
     .putList("http.hosts", "http://localhost:9200")
     .put("http.compression", true)
@@ -63,90 +59,90 @@ Settings settings = Settings.builder()
 
 Client client = new HttpClient(settings, null);
 
-// Perform a search
 client.prepareSearch("my_index")
     .setQuery(QueryBuilders.matchAllQuery())
     .execute(wrap(response -> {
-        long totalHits = response.getHits().getTotalHits().value;
+        long totalHits = response.getHits().getTotalHits().value();
         System.out.println("Found " + totalHits + " documents");
     }, exception -> {
         System.err.println("Search failed: " + exception.getMessage());
     }));
+
+// client.close() when the client is no longer needed
 ```
 
-### With Authentication
+The second constructor argument is a `ThreadPool`. Passing `null` is fine; `HttpClient` creates its own internal thread pool from the `thread_pool.http.*` settings.
+
+## Configuration
+
+`http.hosts` is the only required setting. Everything else has a sensible default.
+
+### Connection
+
+| Setting | Description | Default |
+|---|---|---|
+| `http.hosts` | List of node URLs (`http://` is assumed if the scheme is omitted) | required |
+| `http.compression` | Enable GZIP compression | `true` |
+| `http.heartbeat_interval` | Node health-check interval, in milliseconds | `10000` |
+| `http.connection_timeout` | Connection timeout, in milliseconds (`0` = no timeout) | `0` |
+| `http.socket_timeout` | Socket read timeout, in milliseconds (`0` = no timeout) | `0` |
+
+### Authentication and TLS
+
+| Setting | Description |
+|---|---|
+| `fesen.username` | HTTP Basic authentication username |
+| `fesen.password` | HTTP Basic authentication password |
+| `http.ssl.certificate_authorities` | Path to a CA certificate file used to validate the server's TLS certificate |
+
+### Proxy
+
+| Setting | Description |
+|---|---|
+| `http.proxy_host` | Proxy server hostname |
+| `http.proxy_port` | Proxy server port |
+| `http.proxy_username` | Proxy authentication username |
+| `http.proxy_password` | Proxy authentication password |
+
+### Thread pool
+
+| Setting | Description | Default |
+|---|---|---|
+| `thread_pool.http.size` | Size of the internal HTTP thread pool | number of CPU cores |
+| `thread_pool.http.async` | Run requests asynchronously through the thread pool | `false` |
+
+### Example: multiple nodes with authentication and TLS
 
 ```java
 Settings settings = Settings.builder()
-    .putList("http.hosts", "https://opensearch-cluster:9200")
+    .putList("http.hosts",
+        "https://node1:9200",
+        "https://node2:9200",
+        "https://node3:9200")
+    .put("http.heartbeat_interval", 5000L)
     .put("fesen.username", "admin")
     .put("fesen.password", "admin")
     .put("http.ssl.certificate_authorities", "/path/to/ca.pem")
-    .put("http.compression", true)
     .build();
 
 Client client = new HttpClient(settings, null);
 ```
 
-### Multiple Nodes with Failover
+### Custom request headers
+
+`HttpClient.addRequestBuilder` registers a function that is applied to every outgoing curl4j request, which is useful for adding headers such as API keys:
 
 ```java
-Settings settings = Settings.builder()
-    .putList("http.hosts", 
-        "http://node1:9200", 
-        "http://node2:9200", 
-        "http://node3:9200")
-    .put("http.heartbeat_interval", 5000L)  // Health check every 5 seconds
-    .put("http.compression", true)
-    .build();
+import org.codelibs.curl.CurlRequest;
 
-Client client = new HttpClient(settings, null);
+HttpClient httpClient = new HttpClient(settings, null);
+httpClient.addRequestBuilder(request -> request.header("X-Custom-Header", "MyValue"));
 ```
 
-## ⚙️ Configuration Options
+## Usage Examples
 
-### Essential Settings
+### Index a document
 
-| Setting | Description | Default | Example |
-|---------|-------------|---------|---------|
-| `http.hosts` | List of OpenSearch/Elasticsearch node URLs | Required | `["http://localhost:9200"]` |
-| `http.compression` | Enable GZIP compression | `true` | `true` |
-| `http.heartbeat_interval` | Health check interval in milliseconds | `10000` | `5000` |
-
-### Authentication Settings
-
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `fesen.username` | Basic authentication username | `"admin"` |
-| `fesen.password` | Basic authentication password | `"password"` |
-
-### SSL/TLS Settings
-
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `http.ssl.certificate_authorities` | Path to CA certificate file | `"/path/to/ca.pem"` |
-
-### Proxy Settings
-
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `http.proxy_host` | Proxy server hostname | `"proxy.example.com"` |
-| `http.proxy_port` | Proxy server port | `"8080"` |
-| `http.proxy_username` | Proxy authentication username | `"proxyuser"` |
-| `http.proxy_password` | Proxy authentication password | `"proxypass"` |
-
-### Thread Pool Settings
-
-| Setting | Description | Default | Example |
-|---------|-------------|---------|---------|
-| `thread_pool.http.size` | HTTP client thread pool size | CPU cores | `8` |
-| `thread_pool.http.async` | Enable async mode for thread pool | `false` | `true` |
-
-## 📚 API Examples
-
-### Document Operations
-
-#### Index a Document
 ```java
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.common.xcontent.XContentType;
@@ -155,14 +151,13 @@ IndexRequest request = new IndexRequest("my_index")
     .id("1")
     .source("{\"name\": \"John Doe\", \"age\": 30}", XContentType.JSON);
 
-client.index(request, wrap(response -> {
-    System.out.println("Document indexed: " + response.getId());
-}, exception -> {
-    System.err.println("Index failed: " + exception.getMessage());
-}));
+client.index(request, wrap(
+    response -> System.out.println("Indexed: " + response.getId()),
+    exception -> System.err.println("Index failed: " + exception.getMessage())));
 ```
 
-#### Get a Document
+### Get a document
+
 ```java
 import org.opensearch.action.get.GetRequest;
 
@@ -170,15 +165,13 @@ GetRequest request = new GetRequest("my_index", "1");
 
 client.get(request, wrap(response -> {
     if (response.isExists()) {
-        String source = response.getSourceAsString();
-        System.out.println("Document: " + source);
+        System.out.println("Document: " + response.getSourceAsString());
     }
-}, exception -> {
-    System.err.println("Get failed: " + exception.getMessage());
-}));
+}, exception -> System.err.println("Get failed: " + exception.getMessage())));
 ```
 
-#### Bulk Operations
+### Bulk indexing
+
 ```java
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.index.IndexRequest;
@@ -187,109 +180,16 @@ BulkRequest bulkRequest = new BulkRequest();
 for (int i = 0; i < 1000; i++) {
     bulkRequest.add(new IndexRequest("my_index")
         .id(String.valueOf(i))
-        .source("{\"id\": " + i + ", \"name\": \"User " + i + "\"}", XContentType.JSON));
+        .source("{\"id\": " + i + "}", XContentType.JSON));
 }
 
-client.bulk(bulkRequest, wrap(response -> {
-    System.out.println("Bulk operation completed with " + response.getItems().length + " items");
-}, exception -> {
-    System.err.println("Bulk operation failed: " + exception.getMessage());
-}));
+client.bulk(bulkRequest, wrap(
+    response -> System.out.println("Indexed " + response.getItems().length + " documents"),
+    exception -> System.err.println("Bulk request failed: " + exception.getMessage())));
 ```
 
-### Search Operations
+### Create an index
 
-#### Basic Search
-```java
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.builder.SearchSourceBuilder;
-
-SearchRequest request = new SearchRequest("my_index");
-SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-sourceBuilder.query(QueryBuilders.termQuery("name.keyword", "John Doe"));
-sourceBuilder.size(100);
-request.source(sourceBuilder);
-
-client.search(request, wrap(response -> {
-    response.getHits().forEach(hit -> {
-        System.out.println("Found: " + hit.getSourceAsString());
-    });
-}, exception -> {
-    System.err.println("Search failed: " + exception.getMessage());
-}));
-```
-
-#### Aggregations
-```java
-import org.opensearch.search.aggregations.AggregationBuilders;
-
-SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-sourceBuilder.query(QueryBuilders.matchAllQuery());
-sourceBuilder.aggregation(
-    AggregationBuilders.terms("age_groups").field("age").size(10)
-);
-sourceBuilder.size(0); // No documents, just aggregations
-
-SearchRequest request = new SearchRequest("my_index");
-request.source(sourceBuilder);
-
-client.search(request, wrap(response -> {
-    // Process aggregations
-    response.getAggregations().forEach(agg -> {
-        System.out.println("Aggregation: " + agg.getName());
-    });
-}, exception -> {
-    System.err.println("Aggregation search failed: " + exception.getMessage());
-}));
-```
-
-#### Scroll API for Large Results
-```java
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchScrollRequest;
-import org.opensearch.common.unit.TimeValue;
-
-SearchRequest request = new SearchRequest("my_index");
-request.scroll(TimeValue.timeValueMinutes(1L));
-SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-sourceBuilder.query(QueryBuilders.matchAllQuery());
-sourceBuilder.size(1000);
-request.source(sourceBuilder);
-
-client.search(request, wrap(response -> {
-    String scrollId = response.getScrollId();
-    // Process first batch
-    processHits(response.getHits());
-    
-    // Continue scrolling
-    continueScrolling(client, scrollId);
-}, exception -> {
-    System.err.println("Scroll search failed: " + exception.getMessage());
-}));
-
-private void continueScrolling(Client client, String scrollId) {
-    SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-    scrollRequest.scroll(TimeValue.timeValueMinutes(1L));
-    
-    client.searchScroll(scrollRequest, wrap(response -> {
-        if (response.getHits().getHits().length > 0) {
-            processHits(response.getHits());
-            // Continue with next batch
-            continueScrolling(client, response.getScrollId());
-        } else {
-            // No more results, clear scroll
-            client.prepareClearScroll().addScrollId(scrollId).execute();
-        }
-    }, exception -> {
-        System.err.println("Scroll continuation failed: " + exception.getMessage());
-    }));
-}
-```
-
-### Index Management
-
-#### Create Index with Mapping
 ```java
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 
@@ -298,331 +198,113 @@ request.mapping("""
     {
         "properties": {
             "name": {"type": "text"},
-            "age": {"type": "integer"},
             "created_at": {"type": "date"}
         }
     }
     """, XContentType.JSON);
 
-client.admin().indices().create(request, wrap(response -> {
-    System.out.println("Index created: " + response.index());
-}, exception -> {
-    System.err.println("Index creation failed: " + exception.getMessage());
-}));
+client.admin().indices().create(request, wrap(
+    response -> System.out.println("Created: " + response.index()),
+    exception -> System.err.println("Create failed: " + exception.getMessage())));
 ```
 
-#### Update Index Settings
-```java
-import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+### Cluster health
 
-UpdateSettingsRequest request = new UpdateSettingsRequest("my_index");
-request.settings(Settings.builder()
-    .put("index.refresh_interval", "30s")
-    .put("index.number_of_replicas", 2)
-);
-
-client.admin().indices().putSettings(request, wrap(response -> {
-    System.out.println("Settings updated successfully");
-}, exception -> {
-    System.err.println("Settings update failed: " + exception.getMessage());
-}));
-```
-
-### Cluster Operations
-
-#### Cluster Health
 ```java
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 
-ClusterHealthRequest request = new ClusterHealthRequest();
-request.indices("my_index");
-
-client.admin().cluster().health(request, wrap(response -> {
-    System.out.println("Cluster status: " + response.getStatus());
-    System.out.println("Active shards: " + response.getActiveShards());
-}, exception -> {
-    System.err.println("Health check failed: " + exception.getMessage());
-}));
+client.admin().cluster().health(new ClusterHealthRequest(), wrap(
+    response -> System.out.println("Status: " + response.getStatus()),
+    exception -> System.err.println("Health check failed: " + exception.getMessage())));
 ```
 
-## 🏗 Architecture Overview
+Search, scroll, point-in-time, aggregations, and other read/write operations follow the same pattern using the corresponding request classes from `org.opensearch.action.*`. `HttpClient` covers close to the full REST API surface; see the `action` package described below for the complete list.
 
-### Core Components
+## Supported Engines
 
-The Fesen HttpClient is built around several key architectural components:
+The integration test suite runs against the following versions using Testcontainers:
 
-#### HttpClient
-- **Location**: `src/main/java/org/codelibs/fesen/client/HttpClient.java`
-- **Purpose**: Main client class that extends `HttpAbstractClient`
-- **Responsibilities**: 
-  - Implements OpenSearch `Client` interface over HTTP
-  - Manages connection pooling, authentication, SSL, and proxy configuration
-  - Maps OpenSearch actions to HTTP action implementations
+| Engine | Versions tested |
+|---|---|
+| OpenSearch | 1.3.20, 2.19.4, 3.7.0 |
+| Elasticsearch | 7.17.29, 8.19.11 |
 
-#### NodeManager
-- **Location**: `src/main/java/org/codelibs/fesen/client/node/NodeManager.java`
-- **Purpose**: Manages multiple OpenSearch node endpoints
-- **Features**:
-  - Health checking and failover logic
-  - Background heartbeat checks to detect node availability
-  - Automatic request routing to available nodes
+`HttpClient` inspects the cluster's root endpoint (`GET /`) to determine which engine and major version it is talking to, and adjusts request/response handling where the two diverge.
 
-#### HTTP Actions
-- **Location**: `src/main/java/org/codelibs/fesen/client/action/`
-- **Purpose**: Each OpenSearch API operation has a corresponding `Http*Action` class
-- **Function**: Translates OpenSearch requests to HTTP calls and responses back to OpenSearch objects
-- **Examples**: `HttpSearchAction`, `HttpIndexAction`, `HttpBulkAction`
+## How It Works
 
-### Integration Patterns
+- `HttpClient` (`src/main/java/org/codelibs/fesen/client/HttpClient.java`) is the entry point. It implements the OpenSearch `Client` interface, owns the connection settings (authentication, TLS, proxy, thread pool), and dispatches each action type to its HTTP implementation.
+- `NodeManager` (`.../client/node/`) tracks the configured nodes, runs periodic heartbeat checks, and routes requests away from nodes that are currently unavailable.
+- `action` (`.../client/action/`) contains one `Http*Action` class per REST API operation (for example `HttpSearchAction`, `HttpIndexAction`, `HttpBulkAction`). Each class builds the HTTP request for its operation and parses the response back into the matching OpenSearch response object.
+- `EngineInfo` and `HttpAdminClient`/`HttpIndicesAdminClient` handle engine detection and the cluster/indices admin APIs respectively.
+- `curl` (`.../client/curl/`) wraps [curl4j](https://github.com/codelibs/curl4j) requests with the settings configured on `HttpClient`.
 
-- **Action Pattern**: Each OpenSearch operation is implemented as a separate action class
-- **Factory Pattern**: `HttpClient` acts as a factory for creating configured HTTP requests
-- **Adapter Pattern**: Translates between OpenSearch API and HTTP REST calls
-- **Observer Pattern**: Uses ActionListener callbacks for asynchronous operations
-
-## 🧪 Testing
-
-The project includes comprehensive tests for different OpenSearch/Elasticsearch versions:
-
-### Running Tests
+## Building and Testing
 
 ```bash
-# Run all tests
-mvn test
-
-# Run tests for specific OpenSearch version
-mvn test -Dtest=OpenSearch3ClientTest
-
-# Run tests with pattern matching
-mvn test -Dtest=*ClientTest
-
-# Generate coverage report
-mvn jacoco:report
-```
-
-### Test Structure
-
-- **Integration Tests**: Version-specific test classes for each supported version
-  - `OpenSearch1ClientTest`, `OpenSearch2ClientTest`, `OpenSearch3ClientTest`
-  - `Elasticsearch7ClientTest`, `Elasticsearch8ClientTest`
-- **TestContainers**: Uses Docker containers to test against real instances
-- **Unit Tests**: Component-level tests for utilities and individual actions
-
-### Test Configuration
-
-Tests use TestContainers to spin up real OpenSearch/Elasticsearch instances:
-
-```java
-@Test
-void testBasicOperations() {
-    // TestContainers automatically manages cluster lifecycle
-    // Tests run against real OpenSearch instance
-}
-```
-
-## 🔨 Development
-
-### Building from Source
-
-```bash
-# Clone the repository
 git clone https://github.com/codelibs/fesen-httpclient.git
 cd fesen-httpclient
 
-# Compile the project
-mvn clean compile
-
-# Run tests
-mvn clean test
-
-# Build JAR package
-mvn clean package
-
-# Install to local repository
-mvn clean install
+mvn clean compile      # compile
+mvn clean test          # run the test suite (requires Docker; see below)
+mvn clean package       # build the jar
+mvn clean install       # install to the local repository
 ```
 
-### Code Formatting
-
-The project uses automatic code formatting:
+The test suite uses [Testcontainers](https://testcontainers.com/) to start real OpenSearch/Elasticsearch instances in Docker, one version-specific test class per engine (`OpenSearch1ClientTest`, `OpenSearch2ClientTest`, `OpenSearch3ClientTest`, `Elasticsearch7ClientTest`, `Elasticsearch8ClientTest`). Docker must be running locally. To run a single engine's tests:
 
 ```bash
-# Format code using Eclipse formatter
-mvn formatter:format
+mvn test -Dtest=OpenSearch3ClientTest
+```
 
-# Apply license headers
+Before committing, format the code and apply license headers:
+
+```bash
+mvn formatter:format
 mvn license:format
 ```
 
-### Development Requirements
+A coverage report is produced automatically under `target/site/jacoco` during `mvn package`, or on demand with `mvn jacoco:report`.
 
-- **Java Development Kit**: 17 or higher
-- **Maven**: 3.6.0 or higher
-- **IDE**: Any Java IDE with Maven support
-- **Docker**: Required for running integration tests
+## Troubleshooting
 
-### Project Structure
+**Connection refused** (`org.codelibs.curl.CurlException: Connection refused`)
+Verify that the cluster is running and reachable at the host and port configured in `http.hosts`.
 
-```
-fesen-httpclient/
-├── src/
-│   ├── main/java/org/codelibs/fesen/client/
-│   │   ├── HttpClient.java              # Main client implementation
-│   │   ├── action/                      # HTTP action implementations
-│   │   │   ├── HttpSearchAction.java
-│   │   │   ├── HttpIndexAction.java
-│   │   │   └── ...
-│   │   ├── node/                        # Node management
-│   │   │   ├── NodeManager.java
-│   │   │   └── Node.java
-│   │   └── util/                        # Utility classes
-│   └── test/java/                       # Test classes
-├── pom.xml                              # Maven configuration
-├── CLAUDE.md                            # Development instructions
-└── README.md                            # This file
-```
+**Authentication failed** (`org.opensearch.OpenSearchStatusException: security_exception`)
+Check the `fesen.username`/`fesen.password` credentials and the permissions of that user.
 
-## 🔧 Advanced Configuration
+**TLS handshake failure** (`javax.net.ssl.SSLHandshakeException`)
+Check the `http.ssl.certificate_authorities` path and make sure the certificate is valid and trusted.
 
-### Custom Thread Pool Configuration
+**No available nodes** (`org.codelibs.fesen.client.node.NodeUnavailableException`)
+All configured nodes are currently failing health checks. Verify network connectivity and cluster health, and consider adjusting `http.heartbeat_interval`.
 
-```java
-Settings settings = Settings.builder()
-    .putList("http.hosts", "http://localhost:9200")
-    .put("thread_pool.http.size", 16)      // Custom thread pool size
-    .put("thread_pool.http.async", true)   // Enable async mode
-    .build();
-```
-
-### SSL Configuration with Custom Trust Store
-
-```java
-Settings settings = Settings.builder()
-    .putList("http.hosts", "https://secure-cluster:9200")
-    .put("http.ssl.certificate_authorities", "/path/to/custom-ca.pem")
-    .put("fesen.username", "username")
-    .put("fesen.password", "password")
-    .build();
-```
-
-### Proxy Configuration
-
-```java
-Settings settings = Settings.builder()
-    .putList("http.hosts", "http://remote-cluster:9200")
-    .put("http.proxy_host", "corporate-proxy.company.com")
-    .put("http.proxy_port", "8080")
-    .put("http.proxy_username", "proxy-user")
-    .put("http.proxy_password", "proxy-pass")
-    .build();
-```
-
-### Custom Request Builders
-
-You can add custom request builders for additional configuration:
-
-```java
-HttpClient httpClient = new HttpClient(settings, null);
-
-// Add custom headers to all requests
-httpClient.addRequestBuilder(request -> 
-    request.header("X-Custom-Header", "MyValue")
-);
-
-// Add request logging
-httpClient.addRequestBuilder(request -> {
-    System.out.println("Making request to: " + request.url());
-    return request;
-});
-```
-
-## ❓ Troubleshooting
-
-### Common Issues
-
-#### Connection Refused
-```
-org.codelibs.curl.CurlException: Connection refused
-```
-**Solution**: Verify that OpenSearch/Elasticsearch is running and accessible at the configured host and port.
-
-#### Authentication Failed
-```
-org.opensearch.OpenSearchStatusException: security_exception
-```
-**Solution**: Check username/password credentials and ensure the user has necessary permissions.
-
-#### SSL Certificate Issues
-```
-javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException
-```
-**Solution**: Verify the certificate authority file path and ensure the certificate is valid.
-
-#### Node Unavailable
-```
-org.codelibs.fesen.client.node.NodeUnavailableException: No available nodes
-```
-**Solution**: Check network connectivity and ensure at least one node in the cluster is healthy.
-
-### Enable Debug Logging
-
-Add the following to your logging configuration:
+**Debug logging** — for Log4j2:
 
 ```properties
-# For Log4j2
 logger.fesen.name = org.codelibs.fesen.client
 logger.fesen.level = DEBUG
-
-# For java.util.logging
-org.codelibs.fesen.client.level = FINE
 ```
 
-### Performance Tuning
+## Contributing
 
-#### Connection Pool Optimization
-```java
-Settings settings = Settings.builder()
-    .putList("http.hosts", hosts)
-    .put("thread_pool.http.size", Runtime.getRuntime().availableProcessors() * 2)
-    .put("http.compression", true)
-    .put("http.heartbeat_interval", 30000L)  // Reduce health check frequency
-    .build();
-```
-
-#### Bulk Operation Best Practices
-- Use bulk operations for multiple documents
-- Batch size of 1000-5000 documents typically works well
-- Monitor memory usage with large bulk operations
-
-## 📄 License
-
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
-
-## 🤝 Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome. For anything beyond a small fix, please open an issue first to discuss the change.
 
 1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes, with tests
+4. Run `mvn formatter:format && mvn license:format` and `mvn clean test`
+5. Open a pull request
 
-### Development Guidelines
+## License
 
-- Follow the existing code style and formatting
-- Add tests for new features
-- Update documentation as needed
-- Ensure all tests pass before submitting
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
 
-## 📞 Support
+## Links
 
-- **GitHub Issues**: [Report bugs or request features](https://github.com/codelibs/fesen-httpclient/issues)
-- **Organization**: [CodeLibs Project](https://www.codelibs.org/)
-
-## 🔗 Related Projects
-
-- **OpenSearch**: [https://opensearch.org/](https://opensearch.org/)
-- **Elasticsearch**: [https://www.elastic.co/elasticsearch/](https://www.elastic.co/elasticsearch/)
-- **curl4j**: [https://github.com/codelibs/curl4j](https://github.com/codelibs/curl4j)
-- **CodeLibs**: [https://www.codelibs.org/](https://www.codelibs.org/)
+- [Issue tracker](https://github.com/codelibs/fesen-httpclient/issues)
+- [CodeLibs Project](https://www.codelibs.org/)
+- [OpenSearch](https://opensearch.org/)
+- [Elasticsearch](https://www.elastic.co/elasticsearch/)
+- [curl4j](https://github.com/codelibs/curl4j)


### PR DESCRIPTION
## Summary
- Remove decorative emoji from section headings and trim marketing-style language
- Consolidate configuration and usage examples that were previously duplicated across three sections (Quick Start, Configuration, Advanced Configuration)
- Fix two sample code snippets that no longer matched the current dependency versions: a `CurlRequest#url()` call that does not exist, and `TotalHits#value` field access, which is now the record accessor `value()` in the Lucene version bundled with OpenSearch 3.7.0
- Add a table listing the OpenSearch/Elasticsearch versions actually exercised by the integration test suite
- Simplify the architecture section into a short description of the actual classes instead of a list of design-pattern names

## Test plan
- [x] Verified `TotalHits.value()` and `CreateIndexResponse.index()` signatures against the `opensearch-3.7.0`/`lucene-core-10.4.0` jars
- [x] Verified `CurlRequest#header(String, String)` and `HttpClient#addRequestBuilder(UnaryOperator<CurlRequest>)` against the `curl4j` sources
- [ ] No functional code changes; documentation only