### PR TITLE
chore(deps): bump OpenSearch to 3.8.0, keep 3.7 compatibility, fix nodes stats parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The integration test suite runs against the following versions using Testcontain
 
 | Engine | Versions tested |
 |---|---|
-| OpenSearch | 1.3.20, 2.19.4, 3.7.0 |
+| OpenSearch | 1.3.20, 2.19.4, 3.8.0 |
 | Elasticsearch | 7.17.29, 8.19.11 |
 
 `HttpClient` inspects the cluster's root endpoint (`GET /`) to determine which engine and major version it is talking to, and adjusts request/response handling where the two diverge.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>fesen-httpclient</artifactId>
 	<packaging>jar</packaging>
 	<name>fesen-httpclient</name>
-	<version>3.7.1-SNAPSHOT</version>
+	<version>3.8.0-SNAPSHOT</version>
 	<description>HTTP client for OpenSearch</description>
 	<url>https://github.com/codelibs/fesen-httpclient</url>
 	<inceptionYear>2012</inceptionYear>
@@ -37,7 +37,7 @@
   </scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<opensearch.version>3.7.0</opensearch.version>
+		<opensearch.version>3.8.0</opensearch.version>
 		<log4j.version>2.25.4</log4j.version>
 		<junit.jupiter.version>5.12.2</junit.jupiter.version>
 		<testcontainers.version>1.21.4</testcontainers.version>

--- a/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
+++ b/src/main/java/org/codelibs/fesen/client/action/HttpNodesStatsAction.java
@@ -86,7 +86,6 @@ import org.opensearch.index.store.StoreStats;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats;
 import org.opensearch.index.store.remote.filecache.AggregateFileCacheStats.FileCacheStatsType;
 import org.opensearch.index.store.remote.filecache.FileCacheStats;
-import org.opensearch.plugin.stats.AnalyticsBackendNativeMemoryStats;
 import org.opensearch.plugin.stats.NativeAllocatorPoolStats;
 import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.index.translog.TranslogStats;
@@ -116,6 +115,10 @@ import org.opensearch.tasks.SearchTaskCancellationStats;
 import org.opensearch.tasks.TaskCancellationStats;
 import org.opensearch.threadpool.ThreadPoolStats;
 import org.opensearch.transport.TransportStats;
+import org.opensearch.ratelimitting.admissioncontrol.stats.AdmissionControllerStats;
+import org.opensearch.node.ResponseCollectorService.ComputedNodeStats;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import java.util.LinkedHashMap;
 
 /**
  * Handles the nodes stats API over HTTP for OpenSearch/Elasticsearch.
@@ -196,6 +199,7 @@ public class HttpNodesStatsAction extends HttpAction {
                 fieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if ("_nodes".equals(fieldName)) {
+                    parser.nextToken();
                     parseNodeResults(parser);
                 } else if ("nodes".equals(fieldName)) {
                     parser.nextToken();
@@ -279,7 +283,6 @@ public class HttpNodesStatsAction extends HttpAction {
         NodeCacheStats nodeCacheStats = null;
         RemoteStoreNodeStats remoteStoreNodeStats = null;
         NativeAllocatorPoolStats nativeAllocatorStats = null;
-        AnalyticsBackendNativeMemoryStats nativeMemoryStats = null;
         long totalEstimatedNativeBytes = -1L;
         final Map<String, String> attributes = new HashMap<>();
         XContentParser.Token token;
@@ -337,6 +340,11 @@ public class HttpNodesStatsAction extends HttpAction {
                 } else if ("block_cache".equals(fieldName)) {
                     blockCacheOnlyStats = parseBlockCacheStats(parser);
                 } else if ("native_memory".equals(fieldName)) {
+                    long runtimeAllocatedBytes = 0;
+                    long runtimeResidentBytes = 0;
+                    List<NativeAllocatorPoolStats.PoolStats> memoryPools = null;
+                    NativeAllocatorPoolStats legacyNativeAllocatorStats = null;
+                    boolean hasRuntime = false;
                     String nmFieldName = null;
                     XContentParser.Token nmToken;
                     while ((nmToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
@@ -348,15 +356,37 @@ public class HttpNodesStatsAction extends HttpAction {
                             }
                         } else if (nmToken == XContentParser.Token.START_OBJECT) {
                             parser.nextToken();
-                            if ("analytics_backend".equals(nmFieldName)) {
-                                nativeMemoryStats = parseAnalyticsBackendNativeMemoryStats(parser);
+                            if ("runtime".equals(nmFieldName)) {
+                                hasRuntime = true;
+                                String runtimeFieldName = null;
+                                XContentParser.Token runtimeToken;
+                                while ((runtimeToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                                    if (runtimeToken == XContentParser.Token.FIELD_NAME) {
+                                        runtimeFieldName = parser.currentName();
+                                    } else if (runtimeToken == XContentParser.Token.VALUE_NUMBER) {
+                                        if ("allocated_bytes".equals(runtimeFieldName)) {
+                                            runtimeAllocatedBytes = parser.longValue();
+                                        } else if ("resident_bytes".equals(runtimeFieldName)) {
+                                            runtimeResidentBytes = parser.longValue();
+                                        }
+                                    }
+                                    parser.nextToken();
+                                }
+                            } else if ("memory_pools".equals(nmFieldName)) {
+                                memoryPools = parseNativeMemoryPools(parser);
                             } else if ("native_allocator".equals(nmFieldName)) {
-                                nativeAllocatorStats = parseNativeAllocatorPoolStats(parser);
+                                legacyNativeAllocatorStats = parseLegacyNativeAllocatorStats(parser);
                             } else {
                                 consumeObject(parser);
                             }
                         }
                         parser.nextToken();
+                    }
+                    if (hasRuntime || memoryPools != null) {
+                        nativeAllocatorStats = new NativeAllocatorPoolStats(runtimeAllocatedBytes, runtimeResidentBytes,
+                                memoryPools != null ? memoryPools : new ArrayList<>());
+                    } else {
+                        nativeAllocatorStats = legacyNativeAllocatorStats;
                     }
                 } else if ("task_cancellation".equals(fieldName)) {
                     taskCancellationStats = parseTaskCancellationStats(parser);
@@ -365,7 +395,7 @@ public class HttpNodesStatsAction extends HttpAction {
                 } else if ("segment_replication_backpressure".equals(fieldName)) {
                     segmentReplicationRejectionStats = parseSegmentReplicationRejectionStats(parser);
                 } else if ("admission_control".equals(fieldName)) {
-                    consumeObject(parser);
+                    admissionControlStats = parseAdmissionControlStats(parser);
                 } else if ("caches".equals(fieldName)) {
                     consumeObject(parser);
                 } else if ("remote_store".equals(fieldName)) {
@@ -433,7 +463,6 @@ public class HttpNodesStatsAction extends HttpAction {
                 nodeCacheStats, //
                 remoteStoreNodeStats, //
                 nativeAllocatorStats, //
-                nativeMemoryStats, //
                 totalEstimatedNativeBytes);
     }
 
@@ -465,51 +494,295 @@ public class HttpNodesStatsAction extends HttpAction {
     }
 
     /**
-     * Consumes the adaptive selection section and returns empty adaptive selection statistics.
+     * Parses adaptive selection statistics from the response content.
+     *
+     * <p>The rendered {@code rank} is a formatted string derived from the other values, and the
+     * client connection count behind it is never rendered, so both are recomputed from the parsed
+     * averages rather than restored.
      *
      * @param parser the content parser
      * @return the adaptive selection statistics
      * @throws IOException if parsing fails
      */
     protected AdaptiveSelectionStats parseAdaptiveSelectionStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new AdaptiveSelectionStats(Collections.emptyMap(), Collections.emptyMap());
+        final Map<String, Long> clientOutgoingConnections = new HashMap<>();
+        final Map<String, ComputedNodeStats> nodeComputedStats = new HashMap<>();
+        String nodeId = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                nodeId = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                final String id = nodeId;
+                long outgoingSearches = 0;
+                int queueSize = 0;
+                double serviceTime = 0;
+                double responseTime = 0;
+                String subField = null;
+                XContentParser.Token subToken;
+                while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (subToken == XContentParser.Token.FIELD_NAME) {
+                        subField = parser.currentName();
+                    } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                        if ("outgoing_searches".equals(subField)) {
+                            outgoingSearches = parser.longValue();
+                        } else if ("avg_queue_size".equals(subField)) {
+                            queueSize = parser.intValue();
+                        } else if ("avg_service_time_ns".equals(subField)) {
+                            serviceTime = parser.doubleValue();
+                        } else if ("avg_response_time_ns".equals(subField)) {
+                            responseTime = parser.doubleValue();
+                        }
+                    } else {
+                        skipNestedValue(parser);
+                    }
+                    parser.nextToken();
+                }
+                if (id != null) {
+                    clientOutgoingConnections.put(id, outgoingSearches);
+                    nodeComputedStats.put(id, new ComputedNodeStats(id, 0, queueSize, responseTime, serviceTime));
+                }
+            }
+            parser.nextToken();
+        }
+        return new AdaptiveSelectionStats(clientOutgoingConnections, nodeComputedStats);
     }
 
     /**
-     * Consumes the script cache section and returns empty script cache statistics.
+     * Parses script cache statistics from the response content.
+     *
+     * <p>When the node reports per-context entries the statistics are keyed by context name;
+     * otherwise the {@code sum} object is the whole picture and is returned as general statistics.
      *
      * @param parser the content parser
      * @return the script cache statistics
      * @throws IOException if parsing fails
      */
     protected ScriptCacheStats parseScriptCacheStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new ScriptCacheStats(Collections.emptyMap());
+        final Map<String, ScriptStats> contexts = new HashMap<>();
+        ScriptStats sum = null;
+        boolean hasContexts = false;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("sum".equals(fieldName)) {
+                    sum = parseScriptStats(parser);
+                } else {
+                    consumeObject(parser);
+                }
+            } else if ((token == XContentParser.Token.START_ARRAY) && "contexts".equals(fieldName)) {
+                hasContexts = true;
+                parser.nextToken();
+                while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
+                    if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+                        parser.nextToken();
+                        final String[] contextName = new String[1];
+                        final ScriptStats stats = parseScriptContextStats(parser, contextName);
+                        if (contextName[0] != null) {
+                            contexts.put(contextName[0], stats);
+                        }
+                    }
+                    parser.nextToken();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        if (hasContexts) {
+            return new ScriptCacheStats(contexts);
+        }
+        return new ScriptCacheStats(sum != null ? sum : new ScriptStats(0, 0, 0));
     }
 
     /**
-     * Consumes the indexing pressure section and returns empty indexing pressure statistics.
+     * Parses a single entry of the script cache {@code contexts} array.
+     *
+     * @param parser the content parser
+     * @param contextName single element array receiving the context name
+     * @return the statistics for the context
+     * @throws IOException if parsing fails
+     */
+    protected ScriptStats parseScriptContextStats(final XContentParser parser, final String[] contextName) throws IOException {
+        long compilations = 0;
+        long cacheEvictions = 0;
+        long compilationLimitTriggered = 0;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("compilations".equals(fieldName)) {
+                    compilations = parser.longValue();
+                } else if ("cache_evictions".equals(fieldName)) {
+                    cacheEvictions = parser.longValue();
+                } else if ("compilation_limit_triggered".equals(fieldName)) {
+                    compilationLimitTriggered = parser.longValue();
+                }
+            } else if ((token == XContentParser.Token.VALUE_STRING) && "context".equals(fieldName)) {
+                contextName[0] = parser.text();
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return new ScriptStats(compilations, cacheEvictions, compilationLimitTriggered);
+    }
+
+    /**
+     * Parses indexing pressure statistics from the response content.
+     *
+     * <p>{@code all_in_bytes} is not read because it is rendered as the sum of the replica and
+     * combined values rather than stored separately.
      *
      * @param parser the content parser
      * @return the indexing pressure statistics
      * @throws IOException if parsing fails
      */
     protected IndexingPressureStats parseIndexingPressureStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new IndexingPressureStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        final long[] current = new long[4];
+        final long[] total = new long[7];
+        long memoryLimit = 0;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if ((token == XContentParser.Token.START_OBJECT) && "memory".equals(fieldName)) {
+                parser.nextToken();
+                String memField = null;
+                XContentParser.Token memToken;
+                while ((memToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (memToken == XContentParser.Token.FIELD_NAME) {
+                        memField = parser.currentName();
+                    } else if (memToken == XContentParser.Token.VALUE_NUMBER) {
+                        if ("limit_in_bytes".equals(memField)) {
+                            memoryLimit = parser.longValue();
+                        }
+                    } else if (memToken == XContentParser.Token.START_OBJECT) {
+                        parser.nextToken();
+                        if ("current".equals(memField)) {
+                            parseIndexingPressureBucket(parser, current);
+                        } else if ("total".equals(memField)) {
+                            parseIndexingPressureBucket(parser, total);
+                        } else {
+                            consumeObject(parser);
+                        }
+                    }
+                    parser.nextToken();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return new IndexingPressureStats(total[0], total[1], total[2], total[3], current[0], current[1], current[2], current[3], total[4],
+                total[5], total[6], memoryLimit);
     }
 
     /**
-     * Consumes the shard indexing pressure section and returns empty shard indexing pressure statistics.
+     * Parses one of the {@code current} or {@code total} buckets of the indexing pressure section.
+     *
+     * @param parser the content parser
+     * @param values receives combined, coordinating, primary and replica bytes, followed by the
+     *        coordinating, primary and replica rejection counts when the array is long enough
+     * @throws IOException if parsing fails
+     */
+    protected void parseIndexingPressureBucket(final XContentParser parser, final long[] values) throws IOException {
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("combined_coordinating_and_primary_in_bytes".equals(fieldName)) {
+                    values[0] = parser.longValue();
+                } else if ("coordinating_in_bytes".equals(fieldName)) {
+                    values[1] = parser.longValue();
+                } else if ("primary_in_bytes".equals(fieldName)) {
+                    values[2] = parser.longValue();
+                } else if ("replica_in_bytes".equals(fieldName)) {
+                    values[3] = parser.longValue();
+                } else if ((values.length > 6) && "coordinating_rejections".equals(fieldName)) {
+                    values[4] = parser.longValue();
+                } else if ((values.length > 6) && "primary_rejections".equals(fieldName)) {
+                    values[5] = parser.longValue();
+                } else if ((values.length > 6) && "replica_rejections".equals(fieldName)) {
+                    values[6] = parser.longValue();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+    }
+
+    /**
+     * Parses shard indexing pressure statistics from the response content.
+     *
+     * <p>The rejection breakup object is named {@code total_rejections_breakup} when enforcement is
+     * on and {@code total_rejections_breakup_shadow_mode} otherwise, so both names are accepted. The
+     * per-shard {@code stats} entries are keyed by shard id, which the response does not render in a
+     * form that can be turned back into one, so that map stays empty.
      *
      * @param parser the content parser
      * @return the shard indexing pressure statistics
      * @throws IOException if parsing fails
      */
     protected ShardIndexingPressureStats parseShardIndexingPressureStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new ShardIndexingPressureStats(Collections.emptyMap(), 0, 0, 0, false, false);
+        long nodeLimitsRejections = 0;
+        long lastSuccessfulRequestLimitsRejections = 0;
+        long throughputDegradationLimitsRejections = 0;
+        boolean enabled = false;
+        boolean enforced = false;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+                if ("enabled".equals(fieldName)) {
+                    enabled = parser.booleanValue();
+                } else if ("enforced".equals(fieldName)) {
+                    enforced = parser.booleanValue();
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("total_rejections_breakup".equals(fieldName) || "total_rejections_breakup_shadow_mode".equals(fieldName)) {
+                    String subField = null;
+                    XContentParser.Token subToken;
+                    while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (subToken == XContentParser.Token.FIELD_NAME) {
+                            subField = parser.currentName();
+                        } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                            if ("node_limits".equals(subField)) {
+                                nodeLimitsRejections = parser.longValue();
+                            } else if ("no_successful_request_limits".equals(subField)) {
+                                lastSuccessfulRequestLimitsRejections = parser.longValue();
+                            } else if ("throughput_degradation_limits".equals(subField)) {
+                                throughputDegradationLimitsRejections = parser.longValue();
+                            }
+                        } else {
+                            skipNestedValue(parser);
+                        }
+                        parser.nextToken();
+                    }
+                } else {
+                    consumeObject(parser);
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return new ShardIndexingPressureStats(Collections.emptyMap(), nodeLimitsRejections, lastSuccessfulRequestLimitsRejections,
+                throughputDegradationLimitsRejections, enabled, enforced);
     }
 
     /**
@@ -521,8 +794,9 @@ public class HttpNodesStatsAction extends HttpAction {
      */
     protected SearchBackpressureStats parseSearchBackpressureStats(final XContentParser parser) throws IOException {
         SearchBackpressureMode mode = SearchBackpressureMode.DISABLED;
-        SearchTaskStats searchTaskStats = new SearchTaskStats(0, 0, 0, Collections.emptyMap());
-        SearchShardTaskStats searchShardTaskStats = new SearchShardTaskStats(0, 0, 0, Collections.emptyMap());
+        // completion_count is omitted when it is -1, so that is the default rather than zero.
+        SearchTaskStats searchTaskStats = new SearchTaskStats(0, 0, -1, Collections.emptyMap());
+        SearchShardTaskStats searchShardTaskStats = new SearchShardTaskStats(0, 0, -1, Collections.emptyMap());
         String fieldName = null;
         XContentParser.Token token;
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
@@ -530,8 +804,12 @@ public class HttpNodesStatsAction extends HttpAction {
                 fieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
                 parser.nextToken();
-                if ("search_task".equals(fieldName) || "search_shard_task".equals(fieldName)) {
-                    consumeObject(parser);
+                if ("search_task".equals(fieldName)) {
+                    final long[] counts = parseSearchBackpressureTaskCounts(parser);
+                    searchTaskStats = new SearchTaskStats(counts[0], counts[1], counts[2], Collections.emptyMap());
+                } else if ("search_shard_task".equals(fieldName)) {
+                    final long[] counts = parseSearchBackpressureTaskCounts(parser);
+                    searchShardTaskStats = new SearchShardTaskStats(counts[0], counts[1], counts[2], Collections.emptyMap());
                 } else {
                     consumeObject(parser);
                 }
@@ -546,15 +824,101 @@ public class HttpNodesStatsAction extends HttpAction {
     }
 
     /**
-     * Consumes the cluster manager throttling section and returns empty throttling statistics.
+     * Parses the counters of a search backpressure task section.
+     *
+     * <p>The {@code resource_tracker_stats} entries are keyed by tracker type and carry per-tracker
+     * subclasses that the response does not identify, so they are not restored.
+     *
+     * @param parser the content parser
+     * @return the cancellation count, the cancellation limit reached count and the completion count
+     * @throws IOException if parsing fails
+     */
+    protected long[] parseSearchBackpressureTaskCounts(final XContentParser parser) throws IOException {
+        final long[] counts = { 0, 0, -1 };
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("completion_count".equals(fieldName)) {
+                    counts[2] = parser.longValue();
+                }
+            } else if ((token == XContentParser.Token.START_OBJECT) && "cancellation_stats".equals(fieldName)) {
+                parser.nextToken();
+                String subField = null;
+                XContentParser.Token subToken;
+                while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (subToken == XContentParser.Token.FIELD_NAME) {
+                        subField = parser.currentName();
+                    } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                        if ("cancellation_count".equals(subField)) {
+                            counts[0] = parser.longValue();
+                        } else if ("cancellation_limit_reached_count".equals(subField)) {
+                            counts[1] = parser.longValue();
+                        }
+                    } else {
+                        skipNestedValue(parser);
+                    }
+                    parser.nextToken();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return counts;
+    }
+
+    /**
+     * Parses cluster manager throttling statistics from the response content.
      *
      * @param parser the content parser
      * @return the cluster manager throttling statistics
      * @throws IOException if parsing fails
      */
     protected ClusterManagerThrottlingStats parseClusterManagerThrottlingStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new ClusterManagerThrottlingStats();
+        final ClusterManagerThrottlingStats stats = new ClusterManagerThrottlingStats();
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if ((token == XContentParser.Token.START_OBJECT) && "stats".equals(fieldName)) {
+                parser.nextToken();
+                String statsField = null;
+                XContentParser.Token statsToken;
+                while ((statsToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (statsToken == XContentParser.Token.FIELD_NAME) {
+                        statsField = parser.currentName();
+                    } else if ((statsToken == XContentParser.Token.START_OBJECT) && "throttled_tasks_per_task_type".equals(statsField)) {
+                        parser.nextToken();
+                        // total_throttled_tasks is the sum of these entries, so it is not read separately.
+                        String taskType = null;
+                        XContentParser.Token typeToken;
+                        while ((typeToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                            if (typeToken == XContentParser.Token.FIELD_NAME) {
+                                taskType = parser.currentName();
+                            } else if (typeToken == XContentParser.Token.VALUE_NUMBER) {
+                                if (taskType != null) {
+                                    stats.onThrottle(taskType, parser.intValue());
+                                }
+                            } else {
+                                skipNestedValue(parser);
+                            }
+                            parser.nextToken();
+                        }
+                    } else {
+                        skipNestedValue(parser);
+                    }
+                    parser.nextToken();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return stats;
     }
 
     /**
@@ -571,9 +935,11 @@ public class HttpNodesStatsAction extends HttpAction {
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 fieldName = parser.currentName();
-            } else if ((token == XContentParser.Token.VALUE_NUMBER) && "stats".equals(fieldName)) {
+            } else if ((token == XContentParser.Token.START_OBJECT) && "stats".equals(fieldName)) {
+                parser.nextToken();
                 failOpenCount = parseFailOpenCount(parser);
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         final WeightedRoutingStats stats = WeightedRoutingStats.getInstance();
@@ -601,6 +967,7 @@ public class HttpNodesStatsAction extends HttpAction {
             } else if ((token == XContentParser.Token.VALUE_NUMBER) && "fail_open_count".equals(fieldName)) {
                 failOpenCount = parser.intValue();
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return failOpenCount;
@@ -647,6 +1014,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     pinned = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new FileCacheStats(active, total, used, pinned, evicted, removed, hits, misses, statsType);
@@ -675,6 +1043,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     timestamp = parser.longValue();
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
                 if ("full_file_stats".equals(fieldName)) {
                     fullFileStats = parseFileCacheStats(parser, FileCacheStatsType.FULL_FILE_STATS);
                 } else if ("block_file_stats".equals(fieldName)) {
@@ -683,6 +1052,8 @@ public class HttpNodesStatsAction extends HttpAction {
                     overAllStats = parseFileCacheStats(parser, FileCacheStatsType.OVER_ALL_STATS);
                 } else if ("pinned_file_stats".equals(fieldName)) {
                     pinnedFileStats = parseFileCacheStats(parser, FileCacheStatsType.PINNED_FILE_STATS);
+                } else {
+                    consumeObject(parser);
                 }
             }
             parser.nextToken();
@@ -764,44 +1135,80 @@ public class HttpNodesStatsAction extends HttpAction {
     }
 
     /**
-     * Parses analytics backend native memory statistics from the response content.
+     * Parses the native memory pool statistics from the response content.
      *
      * @param parser the content parser
-     * @return the analytics backend native memory statistics
+     * @return the list of native memory pool statistics
      * @throws IOException if parsing fails
      */
-    protected AnalyticsBackendNativeMemoryStats parseAnalyticsBackendNativeMemoryStats(final XContentParser parser) throws IOException {
-        long allocatedBytes = 0;
-        long residentBytes = 0;
-        String fieldName = null;
+    protected List<NativeAllocatorPoolStats.PoolStats> parseNativeMemoryPools(final XContentParser parser) throws IOException {
+        final List<NativeAllocatorPoolStats.PoolStats> pools = new ArrayList<>();
+        String poolName = null;
         XContentParser.Token token;
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
-                fieldName = parser.currentName();
-            } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if ("allocated_bytes".equals(fieldName)) {
-                    allocatedBytes = parser.longValue();
-                } else if ("resident_bytes".equals(fieldName)) {
-                    residentBytes = parser.longValue();
+                poolName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                long allocatedBytes = 0;
+                long peakBytes = 0;
+                long limitBytes = 0;
+                long minBytes = 0;
+                String group = null;
+                final String name = poolName;
+                String subField = null;
+                XContentParser.Token subToken;
+                while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (subToken == XContentParser.Token.FIELD_NAME) {
+                        subField = parser.currentName();
+                    } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                        if ("allocated_bytes".equals(subField)) {
+                            allocatedBytes = parser.longValue();
+                        } else if ("peak_bytes".equals(subField)) {
+                            // Only rendered by OpenSearch 3.7; 3.8 and later drop it.
+                            peakBytes = parser.longValue();
+                        } else if ("limit_bytes".equals(subField)) {
+                            limitBytes = parser.longValue();
+                        } else if ("min_bytes".equals(subField)) {
+                            minBytes = parser.longValue();
+                        }
+                    } else if (subToken == XContentParser.Token.VALUE_STRING) {
+                        if ("group".equals(subField)) {
+                            group = parser.text();
+                        }
+                    } else if (subToken == XContentParser.Token.START_OBJECT) {
+                        parser.nextToken();
+                        consumeObject(parser);
+                    } else if (subToken == XContentParser.Token.START_ARRAY) {
+                        parser.skipChildren();
+                    }
+                    parser.nextToken();
                 }
+                pools.add(new NativeAllocatorPoolStats.PoolStats(name, allocatedBytes, peakBytes, limitBytes, group, minBytes));
             }
             parser.nextToken();
         }
-        return new AnalyticsBackendNativeMemoryStats(allocatedBytes, residentBytes);
+        return pools;
     }
 
     /**
-     * Parses native allocator pool statistics from the response content.
+     * Parses the OpenSearch 3.7 {@code native_allocator} object into the current stats type.
+     *
+     * <p>OpenSearch 3.7 nested the totals under {@code root} and the pools under {@code pools}; 3.8
+     * replaced that with sibling {@code runtime} and {@code memory_pools} objects. The totals are
+     * mapped the same way OpenSearch itself bridges the two formats: allocated bytes carry over and
+     * the old peak becomes the resident value. The old {@code root.limit_bytes} has no counterpart
+     * and is dropped.
      *
      * @param parser the content parser
-     * @return the native allocator pool statistics
+     * @return the native allocator statistics, or null if the object carried neither totals nor pools
      * @throws IOException if parsing fails
      */
-    protected NativeAllocatorPoolStats parseNativeAllocatorPoolStats(final XContentParser parser) throws IOException {
+    protected NativeAllocatorPoolStats parseLegacyNativeAllocatorStats(final XContentParser parser) throws IOException {
         long rootAllocatedBytes = 0;
         long rootPeakBytes = 0;
-        long rootLimitBytes = 0;
-        final List<NativeAllocatorPoolStats.PoolStats> pools = new ArrayList<>();
+        List<NativeAllocatorPoolStats.PoolStats> pools = null;
+        boolean hasRoot = false;
         String fieldName = null;
         XContentParser.Token token;
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
@@ -810,6 +1217,7 @@ public class HttpNodesStatsAction extends HttpAction {
             } else if (token == XContentParser.Token.START_OBJECT) {
                 parser.nextToken();
                 if ("root".equals(fieldName)) {
+                    hasRoot = true;
                     String subField = null;
                     XContentParser.Token subToken;
                     while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
@@ -820,51 +1228,24 @@ public class HttpNodesStatsAction extends HttpAction {
                                 rootAllocatedBytes = parser.longValue();
                             } else if ("peak_bytes".equals(subField)) {
                                 rootPeakBytes = parser.longValue();
-                            } else if ("limit_bytes".equals(subField)) {
-                                rootLimitBytes = parser.longValue();
                             }
+                        } else {
+                            skipNestedValue(parser);
                         }
                         parser.nextToken();
                     }
                 } else if ("pools".equals(fieldName)) {
-                    String poolName = null;
-                    XContentParser.Token poolToken;
-                    while ((poolToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
-                        if (poolToken == XContentParser.Token.FIELD_NAME) {
-                            poolName = parser.currentName();
-                        } else if (poolToken == XContentParser.Token.START_OBJECT) {
-                            parser.nextToken();
-                            long allocatedBytes = 0;
-                            long peakBytes = 0;
-                            long limitBytes = 0;
-                            final String name = poolName;
-                            String subField = null;
-                            XContentParser.Token subToken;
-                            while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
-                                if (subToken == XContentParser.Token.FIELD_NAME) {
-                                    subField = parser.currentName();
-                                } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
-                                    if ("allocated_bytes".equals(subField)) {
-                                        allocatedBytes = parser.longValue();
-                                    } else if ("peak_bytes".equals(subField)) {
-                                        peakBytes = parser.longValue();
-                                    } else if ("limit_bytes".equals(subField)) {
-                                        limitBytes = parser.longValue();
-                                    }
-                                }
-                                parser.nextToken();
-                            }
-                            pools.add(new NativeAllocatorPoolStats.PoolStats(name, allocatedBytes, peakBytes, limitBytes));
-                        }
-                        parser.nextToken();
-                    }
+                    pools = parseNativeMemoryPools(parser);
                 } else {
                     consumeObject(parser);
                 }
             }
             parser.nextToken();
         }
-        return new NativeAllocatorPoolStats(rootAllocatedBytes, rootPeakBytes, rootLimitBytes, pools);
+        if (!hasRoot && pools == null) {
+            return null;
+        }
+        return new NativeAllocatorPoolStats(rootAllocatedBytes, rootPeakBytes, pools != null ? pools : new ArrayList<>());
     }
 
     /**
@@ -919,6 +1300,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalLongRunningCancelledTaskCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new SearchTaskCancellationStats(currentLongRunningCancelledTaskCount, totalLongRunningCancelledTaskCount);
@@ -946,6 +1328,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalLongRunningCancelledTaskCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new SearchShardTaskCancellationStats(currentLongRunningCancelledTaskCount, totalLongRunningCancelledTaskCount);
@@ -1002,21 +1385,130 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalRejectedRequests = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new SegmentReplicationRejectionStats(totalRejectedRequests);
     }
 
     /**
-     * Consumes the remote store section and returns empty remote store node statistics.
+     * Parses admission control statistics from the response content.
+     *
+     * <p>{@link AdmissionControllerStats} can only be built from a running admission controller or
+     * from the wire, so the parsed rejection counts are restored through the wire format.
+     *
+     * @param parser the content parser
+     * @return the admission control statistics
+     * @throws IOException if parsing fails
+     */
+    protected AdmissionControlStats parseAdmissionControlStats(final XContentParser parser) throws IOException {
+        final Map<String, Map<String, Long>> rejectionCountsByController = new LinkedHashMap<>();
+        String controllerName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                controllerName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if (controllerName != null) {
+                    rejectionCountsByController.put(controllerName, parseAdmissionControllerRejectionCounts(parser));
+                } else {
+                    consumeObject(parser);
+                }
+            }
+            parser.nextToken();
+        }
+        try (final ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
+            out.writeVInt(rejectionCountsByController.size());
+            for (final Map.Entry<String, Map<String, Long>> entry : rejectionCountsByController.entrySet()) {
+                out.writeMap(entry.getValue(), StreamOutput::writeString, StreamOutput::writeLong);
+                out.writeString(entry.getKey());
+            }
+            return new AdmissionControlStats(out.toStreamInput());
+        }
+    }
+
+    /**
+     * Parses the {@code transport.rejection_count} map of a single admission controller.
+     *
+     * @param parser the content parser
+     * @return the rejection counts keyed by action
+     * @throws IOException if parsing fails
+     */
+    protected Map<String, Long> parseAdmissionControllerRejectionCounts(final XContentParser parser) throws IOException {
+        final Map<String, Long> rejectionCount = new LinkedHashMap<>();
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("transport".equals(fieldName)) {
+                    String transportField = null;
+                    XContentParser.Token transportToken;
+                    while ((transportToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                        if (transportToken == XContentParser.Token.FIELD_NAME) {
+                            transportField = parser.currentName();
+                        } else if ((transportToken == XContentParser.Token.START_OBJECT) && "rejection_count".equals(transportField)) {
+                            parser.nextToken();
+                            String action = null;
+                            XContentParser.Token countToken;
+                            while ((countToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                                if (countToken == XContentParser.Token.FIELD_NAME) {
+                                    action = parser.currentName();
+                                } else if (countToken == XContentParser.Token.VALUE_NUMBER) {
+                                    if (action != null) {
+                                        rejectionCount.put(action, parser.longValue());
+                                    }
+                                } else {
+                                    skipNestedValue(parser);
+                                }
+                                parser.nextToken();
+                            }
+                        } else {
+                            skipNestedValue(parser);
+                        }
+                        parser.nextToken();
+                    }
+                } else {
+                    consumeObject(parser);
+                }
+            }
+            parser.nextToken();
+        }
+        return rejectionCount;
+    }
+
+    /**
+     * Parses remote store node statistics from the response content.
      *
      * @param parser the content parser
      * @return the remote store node statistics
      * @throws IOException if parsing fails
      */
     protected RemoteStoreNodeStats parseRemoteStoreNodeStats(final XContentParser parser) throws IOException {
-        consumeObject(parser);
-        return new RemoteStoreNodeStats();
+        long lastSuccessfulFetchOfPinnedTimestamps = -1L;
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if (RemoteStoreNodeStats.LAST_SUCCESSFUL_FETCH_OF_PINNED_TIMESTAMPS.equals(fieldName)) {
+                    lastSuccessfulFetchOfPinnedTimestamps = parser.longValue();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        // The no-argument constructor reads this node's own pinned timestamp service, which is not
+        // meaningful on a client, so the value from the response is restored over the wire format.
+        try (final ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
+            out.writeLong(lastSuccessfulFetchOfPinnedTimestamps);
+            return new RemoteStoreNodeStats(out.toStreamInput());
+        }
     }
 
     /**
@@ -1047,6 +1539,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     failedCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new OperationStats(count, totalTimeInMillis, current, failedCount);
@@ -1240,6 +1733,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     compatibleClusterStateDiffReceivedCount = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new PublishClusterStateStats(fullClusterStateReceivedCount, incompatibleClusterStateDiffReceivedCount,
@@ -1271,6 +1765,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     committed = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new PendingClusterStateStats(total, pending, committed);
@@ -1301,6 +1796,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     compilationLimitTriggered = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new ScriptStats(compilations, cacheEvictions, compilationLimitTriggered);
@@ -1372,6 +1868,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalOpened = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new HttpStats(serverOpen, totalOpened);
@@ -1411,6 +1908,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     txSize = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new TransportStats(serverOpen, totalOutboundConnections, rxCount, rxSize, txCount, txSize);
@@ -1504,6 +2002,7 @@ public class HttpNodesStatsAction extends HttpAction {
             } else if ((token == XContentParser.Token.VALUE_STRING) && "path".equals(fieldName)) {
                 path = parser.text();
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new DiskUsage(nodeId, nodeName, path, totalBytes, freeBytes);
@@ -1634,6 +2133,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     unloadedClassCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new JvmStats.Classes(loadedClassCount, totalLoadedClassCount, unloadedClassCount);
@@ -1752,6 +2252,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     peakCount = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new JvmStats.Threads(count, peakCount);
@@ -1911,6 +2412,7 @@ public class HttpNodesStatsAction extends HttpAction {
             } else if ((token == XContentParser.Token.VALUE_NUMBER) && "total_virtual_in_bytes".equals(fieldName)) {
                 totalVirtual = parser.longValue();
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new ProcessStats.Mem(totalVirtual);
@@ -1938,6 +2440,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     total = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new ProcessStats.Cpu(percent, total);
@@ -2107,6 +2610,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     free = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new OsStats.Swap(total, free);
@@ -2134,6 +2638,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     free = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new OsStats.Mem(total, free);
@@ -2302,6 +2807,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     throttleTimeInNanos = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         try (ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
@@ -2342,6 +2848,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     missCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new RequestCacheStats(memorySize, evictions, hitCount, missCount);
@@ -2378,6 +2885,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     earliestLastModifiedAge = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new TranslogStats(numberOfOperations, translogSizeInBytes, uncommittedOperations, uncommittedSizeInBytes,
@@ -2387,6 +2895,10 @@ public class HttpNodesStatsAction extends HttpAction {
     /**
      * Parses segment statistics from the response content.
      *
+     * <p>The per-type memory fields (terms, stored fields, term vectors, norms, points and doc
+     * values) were dropped in Lucene 9, are always rendered as zero and are not part of the current
+     * wire format, so they are no longer read.
+     *
      * @param parser the content parser
      * @return the segment statistics
      * @throws IOException if parsing fails
@@ -2394,18 +2906,13 @@ public class HttpNodesStatsAction extends HttpAction {
     protected SegmentsStats parseSegmentsStats(final XContentParser parser) throws IOException {
         String fieldName = null;
         long count = 0;
-        long memoryInBytes = 0;
-        long termsMemoryInBytes = 0;
-        long storedFieldsMemoryInBytes = 0;
-        long termVectorsMemoryInBytes = 0;
-        long normsMemoryInBytes = 0;
-        long pointsMemoryInBytes = 0;
-        long docValuesMemoryInBytes = 0;
         long indexWriterMemoryInBytes = 0;
         long versionMapMemoryInBytes = 0;
         long bitsetMemoryInBytes = 0;
         long maxUnsafeAutoIdTimestamp = 0;
         final Map<String, Long> fileSizes = new HashMap<>();
+        long[] remoteStore = null;
+        long[] segmentReplication = null;
         XContentParser.Token token;
         while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -2419,29 +2926,21 @@ public class HttpNodesStatsAction extends HttpAction {
                             key = parser.currentName();
                         } else if (token == XContentParser.Token.VALUE_NUMBER) {
                             fileSizes.put(key, parser.longValue());
+                        } else {
+                            skipNestedValue(parser);
                         }
                         parser.nextToken();
                     }
+                } else if ("remote_store".equals(fieldName)) {
+                    remoteStore = parseRemoteSegmentStats(parser);
+                } else if ("segment_replication".equals(fieldName)) {
+                    segmentReplication = parseSegmentReplicationStats(parser);
                 } else {
                     consumeObject(parser);
                 }
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
                 if ("count".equals(fieldName)) {
                     count = parser.longValue();
-                } else if ("memory_in_bytes".equals(fieldName)) {
-                    memoryInBytes = parser.longValue();
-                } else if ("terms_memory_in_bytes".equals(fieldName)) {
-                    termsMemoryInBytes = parser.longValue();
-                } else if ("stored_fields_memory_in_bytes".equals(fieldName)) {
-                    storedFieldsMemoryInBytes = parser.longValue();
-                } else if ("term_vectors_memory_in_bytes".equals(fieldName)) {
-                    termVectorsMemoryInBytes = parser.longValue();
-                } else if ("norms_memory_in_bytes".equals(fieldName)) {
-                    normsMemoryInBytes = parser.longValue();
-                } else if ("points_memory_in_bytes".equals(fieldName)) {
-                    pointsMemoryInBytes = parser.longValue();
-                } else if ("doc_values_memory_in_bytes".equals(fieldName)) {
-                    docValuesMemoryInBytes = parser.longValue();
                 } else if ("index_writer_memory_in_bytes".equals(fieldName)) {
                     indexWriterMemoryInBytes = parser.longValue();
                 } else if ("version_map_memory_in_bytes".equals(fieldName)) {
@@ -2451,31 +2950,223 @@ public class HttpNodesStatsAction extends HttpAction {
                 } else if ("max_unsafe_auto_id_timestamp".equals(fieldName)) {
                     maxUnsafeAutoIdTimestamp = parser.longValue();
                 }
+            } else {
+                skipNestedValue(parser);
             }
             parser.nextToken();
         }
         try (ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
             out.writeVLong(count);
-            out.writeLong(memoryInBytes);
-            out.writeLong(termsMemoryInBytes);
-            out.writeLong(storedFieldsMemoryInBytes);
-            out.writeLong(termVectorsMemoryInBytes);
-            out.writeLong(normsMemoryInBytes);
-            out.writeLong(pointsMemoryInBytes);
-            out.writeLong(docValuesMemoryInBytes);
             out.writeLong(indexWriterMemoryInBytes);
             out.writeLong(versionMapMemoryInBytes);
             out.writeLong(bitsetMemoryInBytes);
             out.writeLong(maxUnsafeAutoIdTimestamp);
-            out.writeVInt(fileSizes.size());
-            for (final Map.Entry<String, Long> entry : fileSizes.entrySet()) {
-                out.writeString(entry.getKey());
-                out.writeLong(entry.getValue());
-            }
+            out.writeMap(fileSizes, StreamOutput::writeString, StreamOutput::writeLong);
+            writeOptionalRemoteSegmentStats(out, remoteStore);
+            writeOptionalReplicationStats(out, segmentReplication);
             try (StreamInput in = new InputStreamStreamInput(new ByteArrayInputStream(out.toByteArray()))) {
                 return new SegmentsStats(in);
             }
         }
+    }
+
+    /**
+     * Writes the optional remote segment statistics of the segment statistics wire format.
+     *
+     * @param out the stream to write to
+     * @param values the counters returned by {@link #parseRemoteSegmentStats(XContentParser)}, or null
+     * @throws IOException if writing fails
+     */
+    protected void writeOptionalRemoteSegmentStats(final ByteArrayStreamOutput out, final long[] values) throws IOException {
+        if (values == null) {
+            out.writeBoolean(false);
+            return;
+        }
+        out.writeBoolean(true);
+        for (int i = 0; i < 11; i++) {
+            out.writeLong(values[i]);
+        }
+        out.writeVLong(values[11]);
+    }
+
+    /**
+     * Writes the optional replication statistics of the segment statistics wire format.
+     *
+     * @param out the stream to write to
+     * @param values the counters returned by {@link #parseSegmentReplicationStats(XContentParser)}, or null
+     * @throws IOException if writing fails
+     */
+    protected void writeOptionalReplicationStats(final ByteArrayStreamOutput out, final long[] values) throws IOException {
+        if (values == null) {
+            out.writeBoolean(false);
+            return;
+        }
+        out.writeBoolean(true);
+        out.writeVLong(values[0]);
+        out.writeVLong(values[1]);
+        out.writeVLong(values[2]);
+    }
+
+    /**
+     * Parses the {@code remote_store} object nested in the segment statistics.
+     *
+     * @param parser the content parser
+     * @return the upload and download counters in wire order, with the rejection count last
+     * @throws IOException if parsing fails
+     */
+    protected long[] parseRemoteSegmentStats(final XContentParser parser) throws IOException {
+        // uploadStarted, uploadFailed, uploadSucceeded, downloadStarted, downloadFailed,
+        // downloadSucceeded, maxRefreshTimeLag, maxRefreshBytesLag, totalRefreshBytesLag,
+        // totalUploadTime, totalDownloadTime, totalRejections
+        final long[] values = new long[12];
+        String section = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                section = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                if ("upload".equals(section)) {
+                    parseRemoteSegmentUploadStats(parser, values);
+                } else if ("download".equals(section)) {
+                    parseRemoteSegmentDownloadStats(parser, values);
+                } else {
+                    consumeObject(parser);
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return values;
+    }
+
+    /**
+     * Parses the {@code upload} object of the segment remote store statistics.
+     *
+     * @param parser the content parser
+     * @param values the counter array being filled
+     * @throws IOException if parsing fails
+     */
+    protected void parseRemoteSegmentUploadStats(final XContentParser parser, final long[] values) throws IOException {
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("max_refresh_time_lag_in_millis".equals(fieldName)) {
+                    values[6] = parser.longValue();
+                } else if ("total_time_spent_in_millis".equals(fieldName)) {
+                    values[9] = parser.longValue();
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                final String section = fieldName;
+                String subField = null;
+                XContentParser.Token subToken;
+                while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (subToken == XContentParser.Token.FIELD_NAME) {
+                        subField = parser.currentName();
+                    } else if (subToken == XContentParser.Token.VALUE_NUMBER) {
+                        if ("total_upload_size".equals(section)) {
+                            if ("started_bytes".equals(subField)) {
+                                values[0] = parser.longValue();
+                            } else if ("failed_bytes".equals(subField)) {
+                                values[1] = parser.longValue();
+                            } else if ("succeeded_bytes".equals(subField)) {
+                                values[2] = parser.longValue();
+                            }
+                        } else if ("refresh_size_lag".equals(section)) {
+                            if ("max_bytes".equals(subField)) {
+                                values[7] = parser.longValue();
+                            } else if ("total_bytes".equals(subField)) {
+                                values[8] = parser.longValue();
+                            }
+                        } else if ("pressure".equals(section) && "total_rejections".equals(subField)) {
+                            values[11] = parser.longValue();
+                        }
+                    } else {
+                        skipNestedValue(parser);
+                    }
+                    parser.nextToken();
+                }
+            }
+            parser.nextToken();
+        }
+    }
+
+    /**
+     * Parses the {@code download} object of the segment remote store statistics.
+     *
+     * @param parser the content parser
+     * @param values the counter array being filled
+     * @throws IOException if parsing fails
+     */
+    protected void parseRemoteSegmentDownloadStats(final XContentParser parser, final long[] values) throws IOException {
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("total_time_spent_in_millis".equals(fieldName)) {
+                    values[10] = parser.longValue();
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                parser.nextToken();
+                final String section = fieldName;
+                String subField = null;
+                XContentParser.Token subToken;
+                while ((subToken = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+                    if (subToken == XContentParser.Token.FIELD_NAME) {
+                        subField = parser.currentName();
+                    } else if ((subToken == XContentParser.Token.VALUE_NUMBER) && "total_download_size".equals(section)) {
+                        if ("started_bytes".equals(subField)) {
+                            values[3] = parser.longValue();
+                        } else if ("failed_bytes".equals(subField)) {
+                            values[4] = parser.longValue();
+                        } else if ("succeeded_bytes".equals(subField)) {
+                            values[5] = parser.longValue();
+                        }
+                    } else {
+                        skipNestedValue(parser);
+                    }
+                    parser.nextToken();
+                }
+            }
+            parser.nextToken();
+        }
+    }
+
+    /**
+     * Parses the {@code segment_replication} object nested in the segment statistics.
+     *
+     * @param parser the content parser
+     * @return the max bytes behind, total bytes behind and max replication lag
+     * @throws IOException if parsing fails
+     */
+    protected long[] parseSegmentReplicationStats(final XContentParser parser) throws IOException {
+        final long[] values = new long[3];
+        String fieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.currentToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                if ("max_bytes_behind".equals(fieldName)) {
+                    values[0] = parser.longValue();
+                } else if ("total_bytes_behind".equals(fieldName)) {
+                    values[1] = parser.longValue();
+                } else if ("max_replication_lag".equals(fieldName)) {
+                    values[2] = parser.longValue();
+                }
+            } else {
+                skipNestedValue(parser);
+            }
+            parser.nextToken();
+        }
+        return values;
     }
 
     /**
@@ -2495,6 +3186,7 @@ public class HttpNodesStatsAction extends HttpAction {
             } else if ((token == XContentParser.Token.VALUE_NUMBER) && "size_in_bytes".equals(fieldName)) {
                 size = parser.longValue();
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new CompletionStats(size, null);
@@ -2522,6 +3214,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     evictions = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new FieldDataStats(memorySize, evictions, null);
@@ -2558,6 +3251,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     cacheSize = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new QueryCacheStats(ramBytesUsed, hitCount, missCount, cacheCount, cacheSize);
@@ -2588,6 +3282,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalTimeInMillis = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new WarmerStats(current, total, totalTimeInMillis);
@@ -2618,6 +3313,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalTimeInMillis = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new FlushStats(total, periodic, totalTimeInMillis);
@@ -2654,6 +3350,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     listeners = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new RefreshStats(total, totalTimeInMillis, externalTotal, externalTotalTimeInMillis, listeners);
@@ -2705,6 +3402,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalBytesPerSecAutoThrottle = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         try (ByteArrayStreamOutput out = new ByteArrayStreamOutput()) {
@@ -2803,6 +3501,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     searchIdleReactivateCount = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         long queryConcurrency = 0;
@@ -2863,6 +3562,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     current = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new GetStats(existsCount, existsTimeInMillis, missingCount, missingTimeInMillis, current);
@@ -2916,9 +3616,9 @@ public class HttpNodesStatsAction extends HttpAction {
                 } else if ("throttle_time_in_millis".equals(fieldName)) {
                     throttleTimeInMillis = parser.longValue();
                 }
-            } else if ("doc_status".equals(fieldName)) {
-                consumeObject(parser);
             }
+            // doc_status and any other nested value are handled by skipNestedValue below.
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new IndexingStats(new IndexingStats.Stats(indexCount, indexTimeInMillis, indexCurrent, indexFailedCount, deleteCount,
@@ -2947,6 +3647,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     reservedSize = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new StoreStats(sizeInBytes, reservedSize);
@@ -2977,6 +3678,7 @@ public class HttpNodesStatsAction extends HttpAction {
                     totalSizeInBytes = parser.longValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return new DocsStats(count, deleted, totalSizeInBytes);
@@ -3005,9 +3707,31 @@ public class HttpNodesStatsAction extends HttpAction {
                     results[2] = parser.intValue();
                 }
             }
+            skipNestedValue(parser);
             parser.nextToken();
         }
         return results;
+    }
+
+    /**
+     * Skips a value that the enclosing parse loop does not consume itself.
+     *
+     * <p>Reads the parser's current position rather than the token the iteration started on, so it is
+     * a no-op when the loop body already consumed the value. Without this, a loop that only handles
+     * field names and scalars descends into a nested value and exits at that value's closing token,
+     * leaving the parser out of sync and silently dropping every remaining field.
+     *
+     * @param parser the content parser
+     * @throws IOException if parsing fails
+     */
+    protected void skipNestedValue(final XContentParser parser) throws IOException {
+        final XContentParser.Token token = parser.currentToken();
+        if (token == XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+            consumeObject(parser);
+        } else if (token == XContentParser.Token.START_ARRAY) {
+            parser.skipChildren();
+        }
     }
 
     /**

--- a/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
+++ b/src/test/java/org/codelibs/fesen/client/OpenSearch3ClientTest.java
@@ -129,7 +129,7 @@ import org.testcontainers.utility.DockerImageName;
 class OpenSearch3ClientTest {
     static final Logger logger = Logger.getLogger(OpenSearch3ClientTest.class.getName());
 
-    static final String version = "3.7.0";
+    static final String version = "3.8.0";
 
     static final String imageTag = "public.ecr.aws/opensearchproject/opensearch:" + version;
 

--- a/src/test/java/org/codelibs/fesen/client/action/HttpNodesStatsActionTest.java
+++ b/src/test/java/org/codelibs/fesen/client/action/HttpNodesStatsActionTest.java
@@ -41,12 +41,12 @@ import org.opensearch.action.admin.cluster.node.stats.NodeStats;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsAction;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.plugin.stats.AnalyticsBackendNativeMemoryStats;
 import org.opensearch.plugin.stats.NativeAllocatorPoolStats;
 import org.opensearch.plugins.BlockCacheStats;
 import org.opensearch.search.backpressure.stats.SearchBackpressureStats;
@@ -54,6 +54,22 @@ import org.opensearch.search.pipeline.SearchPipelineStats;
 import org.opensearch.tasks.TaskCancellationStats;
 
 import sun.misc.Unsafe;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import java.util.Map;
+import java.util.HashMap;
+import org.opensearch.index.remote.RemoteSegmentStats;
+import org.opensearch.index.engine.SegmentsStats;
+import org.opensearch.ratelimitting.admissioncontrol.stats.AdmissionControlStats;
+import org.opensearch.node.remotestore.RemoteStoreNodeStats;
+import org.opensearch.node.ResponseCollectorService.ComputedNodeStats;
+import org.opensearch.node.AdaptiveSelectionStats;
+import org.opensearch.cluster.service.ClusterManagerThrottlingStats;
+import org.opensearch.script.ScriptCacheStats;
+import org.opensearch.index.stats.ShardIndexingPressureStats;
+import org.opensearch.index.stats.IndexingPressureStats;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.ToXContent;
 
 /**
  * Tests for {@link HttpNodesStatsAction} JSON parsing logic.
@@ -69,6 +85,10 @@ class HttpNodesStatsActionTest {
         f.setAccessible(true);
         final Unsafe unsafe = (Unsafe) f.get(null);
         action = (HttpNodesStatsAction) unsafe.allocateInstance(HttpNodesStatsAction.class);
+        // allocateInstance skips the constructor, so wire up the one field the indices parser needs.
+        final Field cs = HttpNodesStatsAction.class.getDeclaredField("clusterSettings");
+        cs.setAccessible(true);
+        cs.set(action, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
     }
 
     private XContentParser createParser(final String json) throws IOException {
@@ -1011,91 +1031,63 @@ class HttpNodesStatsActionTest {
         return (BlockCacheStats) m.invoke(action, parser);
     }
 
-    private AnalyticsBackendNativeMemoryStats callParseAnalyticsBackendNativeMemoryStats(final XContentParser parser) throws Exception {
-        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseAnalyticsBackendNativeMemoryStats", XContentParser.class);
+    @SuppressWarnings("unchecked")
+    private List<NativeAllocatorPoolStats.PoolStats> callParseNativeMemoryPools(final XContentParser parser) throws Exception {
+        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseNativeMemoryPools", XContentParser.class);
         m.setAccessible(true);
-        return (AnalyticsBackendNativeMemoryStats) m.invoke(action, parser);
+        return (List<NativeAllocatorPoolStats.PoolStats>) m.invoke(action, parser);
     }
 
-    private NativeAllocatorPoolStats callParseNativeAllocatorPoolStats(final XContentParser parser) throws Exception {
-        final Method m = HttpNodesStatsAction.class.getDeclaredMethod("parseNativeAllocatorPoolStats", XContentParser.class);
-        m.setAccessible(true);
-        return (NativeAllocatorPoolStats) m.invoke(action, parser);
-    }
-
-    // ==================== parseNativeAllocatorPoolStats tests ====================
+    // ==================== parseNativeMemoryPools tests ====================
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void test_parseNativeAllocatorPoolStats_fullParse() throws Exception {
-        final String json = "{" + "\"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30}," + "\"pools\":{"
-                + "  \"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3},"
-                + "  \"pool-b\":{\"allocated_bytes\":4,\"peak_bytes\":5,\"limit_bytes\":6}" + "}" + "}";
+    void test_parseNativeMemoryPools_fullParse() throws Exception {
+        final String json = "{" + "  \"pool-a\":{\"allocated_bytes\":1,\"limit_bytes\":3,\"min_bytes\":2,\"group\":\"arrow\"},"
+                + "  \"pool-b\":{\"allocated_bytes\":4,\"limit_bytes\":6,\"min_bytes\":5}" + "}";
         try (final XContentParser parser = createParser(json)) {
             parser.nextToken(); // advance past START_OBJECT into first field
-            final NativeAllocatorPoolStats stats = callParseNativeAllocatorPoolStats(parser);
-            assertNotNull(stats);
-            assertEquals(10L, stats.getRootAllocatedBytes());
-            assertEquals(20L, stats.getRootPeakBytes());
-            assertEquals(30L, stats.getRootLimitBytes());
-            assertEquals(2, stats.getPools().size());
-            final NativeAllocatorPoolStats.PoolStats poolA = stats.getPools().get(0);
+            final List<NativeAllocatorPoolStats.PoolStats> pools = callParseNativeMemoryPools(parser);
+            assertEquals(2, pools.size());
+            final NativeAllocatorPoolStats.PoolStats poolA = pools.get(0);
             assertEquals("pool-a", poolA.getName());
             assertEquals(1L, poolA.getAllocatedBytes());
-            assertEquals(2L, poolA.getPeakBytes());
             assertEquals(3L, poolA.getLimitBytes());
-            final NativeAllocatorPoolStats.PoolStats poolB = stats.getPools().get(1);
+            assertEquals(2L, poolA.getMinBytes());
+            assertEquals("arrow", poolA.getGroup());
+            final NativeAllocatorPoolStats.PoolStats poolB = pools.get(1);
             assertEquals("pool-b", poolB.getName());
             assertEquals(4L, poolB.getAllocatedBytes());
-            assertEquals(5L, poolB.getPeakBytes());
             assertEquals(6L, poolB.getLimitBytes());
+            assertEquals(5L, poolB.getMinBytes());
+            assertNull(poolB.getGroup());
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         }
     }
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void test_parseNativeAllocatorPoolStats_noPools() throws Exception {
-        final String json = "{\"root\":{\"allocated_bytes\":100,\"peak_bytes\":200,\"limit_bytes\":300}}";
-        try (final XContentParser parser = createParser(json)) {
-            parser.nextToken();
-            final NativeAllocatorPoolStats stats = callParseNativeAllocatorPoolStats(parser);
-            assertNotNull(stats);
-            assertEquals(100L, stats.getRootAllocatedBytes());
-            assertEquals(200L, stats.getRootPeakBytes());
-            assertEquals(300L, stats.getRootLimitBytes());
-            assertNotNull(stats.getPools());
-            assertEquals(0, stats.getPools().size());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-        }
-    }
-
-    // ==================== parseAnalyticsBackendNativeMemoryStats tests ====================
-
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void test_parseAnalyticsBackendNativeMemoryStats_full() throws Exception {
-        final String json = "{\"allocated_bytes\":1111,\"resident_bytes\":2222}";
-        try (final XContentParser parser = createParser(json)) {
-            parser.nextToken();
-            final AnalyticsBackendNativeMemoryStats stats = callParseAnalyticsBackendNativeMemoryStats(parser);
-            assertNotNull(stats);
-            assertEquals(1111L, stats.getAllocatedBytes());
-            assertEquals(2222L, stats.getResidentBytes());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-        }
-    }
-
-    @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    void test_parseAnalyticsBackendNativeMemoryStats_empty() throws Exception {
+    void test_parseNativeMemoryPools_empty() throws Exception {
         final String json = "{}";
         try (final XContentParser parser = createParser(json)) {
             parser.nextToken();
-            final AnalyticsBackendNativeMemoryStats stats = callParseAnalyticsBackendNativeMemoryStats(parser);
-            assertNotNull(stats);
-            assertEquals(0L, stats.getAllocatedBytes());
-            assertEquals(0L, stats.getResidentBytes());
+            final List<NativeAllocatorPoolStats.PoolStats> pools = callParseNativeMemoryPools(parser);
+            assertNotNull(pools);
+            assertEquals(0, pools.size());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNativeMemoryPools_unknownFieldsIgnored() throws Exception {
+        final String json = "{\"pool-a\":{\"allocated_bytes\":7,\"peak_bytes\":99,\"unknown\":{\"a\":1},\"limit_bytes\":8}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final List<NativeAllocatorPoolStats.PoolStats> pools = callParseNativeMemoryPools(parser);
+            assertEquals(1, pools.size());
+            assertEquals(7L, pools.get(0).getAllocatedBytes());
+            assertEquals(8L, pools.get(0).getLimitBytes());
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         }
     }
@@ -1163,35 +1155,31 @@ class HttpNodesStatsActionTest {
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     void test_parseNodeStats_nativeMemoryFull() throws Exception {
         final String json = "{" + "\"name\":\"test-node\"," + "\"timestamp\":1234567890," + "\"native_memory\":{"
-                + "  \"total_estimated_bytes\":123456," + "  \"analytics_backend\":{\"allocated_bytes\":1111,\"resident_bytes\":2222},"
-                + "  \"native_allocator\":{" + "    \"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30},"
-                + "    \"pools\":{" + "      \"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3},"
-                + "      \"pool-b\":{\"allocated_bytes\":4,\"peak_bytes\":5,\"limit_bytes\":6}" + "    }" + "  }" + "}" + "}";
+                + "  \"total_estimated_bytes\":123456," + "  \"runtime\":{\"allocated_bytes\":10,\"resident_bytes\":20},"
+                + "  \"memory_pools\":{" + "    \"pool-a\":{\"allocated_bytes\":1,\"limit_bytes\":3,\"min_bytes\":2},"
+                + "    \"pool-b\":{\"allocated_bytes\":4,\"limit_bytes\":6,\"min_bytes\":5,\"group\":\"arrow\"}" + "  }" + "}" + "}";
         try (final XContentParser parser = createParser(json)) {
             parser.nextToken();
             final NodeStats nodeStats = callParseNodeStats(parser, "node1");
             assertNotNull(nodeStats);
             assertEquals(123456L, nodeStats.getTotalEstimatedNativeBytes());
-            final AnalyticsBackendNativeMemoryStats nativeMemory = nodeStats.getAnalyticsBackendNativeMemoryStats();
-            assertNotNull(nativeMemory);
-            assertEquals(1111L, nativeMemory.getAllocatedBytes());
-            assertEquals(2222L, nativeMemory.getResidentBytes());
             final NativeAllocatorPoolStats nativeAllocator = nodeStats.getNativeAllocatorStats();
             assertNotNull(nativeAllocator);
-            assertEquals(10L, nativeAllocator.getRootAllocatedBytes());
-            assertEquals(20L, nativeAllocator.getRootPeakBytes());
-            assertEquals(30L, nativeAllocator.getRootLimitBytes());
+            assertEquals(10L, nativeAllocator.getNativeAllocatedBytes());
+            assertEquals(20L, nativeAllocator.getNativeResidentBytes());
             assertEquals(2, nativeAllocator.getPools().size());
             final NativeAllocatorPoolStats.PoolStats pool0 = nativeAllocator.getPools().get(0);
             assertEquals("pool-a", pool0.getName());
             assertEquals(1L, pool0.getAllocatedBytes());
-            assertEquals(2L, pool0.getPeakBytes());
             assertEquals(3L, pool0.getLimitBytes());
+            assertEquals(2L, pool0.getMinBytes());
+            assertNull(pool0.getGroup());
             final NativeAllocatorPoolStats.PoolStats pool1 = nativeAllocator.getPools().get(1);
             assertEquals("pool-b", pool1.getName());
             assertEquals(4L, pool1.getAllocatedBytes());
-            assertEquals(5L, pool1.getPeakBytes());
             assertEquals(6L, pool1.getLimitBytes());
+            assertEquals(5L, pool1.getMinBytes());
+            assertEquals("arrow", pool1.getGroup());
         }
     }
 
@@ -1205,7 +1193,6 @@ class HttpNodesStatsActionTest {
             final NodeStats nodeStats = callParseNodeStats(parser, "node1");
             assertNotNull(nodeStats);
             assertEquals(99999L, nodeStats.getTotalEstimatedNativeBytes());
-            assertNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
             assertNull(nodeStats.getNativeAllocatorStats());
         }
     }
@@ -1219,7 +1206,6 @@ class HttpNodesStatsActionTest {
             final NodeStats nodeStats = callParseNodeStats(parser, "node1");
             assertNotNull(nodeStats);
             assertEquals(-1L, nodeStats.getTotalEstimatedNativeBytes());
-            assertNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
             assertNull(nodeStats.getNativeAllocatorStats());
         }
     }
@@ -1352,9 +1338,8 @@ class HttpNodesStatsActionTest {
                 + "    \"pinned_file_stats\":{\"active_in_bytes\":0,\"used_in_bytes\":0,\"pinned_in_bytes\":0,"
                 + "      \"evictions_in_bytes\":0,\"removed_in_bytes\":0,\"active_percent\":0,\"hit_count\":0,\"miss_count\":0}" + "  },"
                 + "  \"native_memory\":{" + "    \"total_estimated_bytes\":123456,"
-                + "    \"analytics_backend\":{\"allocated_bytes\":1111,\"resident_bytes\":2222}," + "    \"native_allocator\":{"
-                + "      \"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30},"
-                + "      \"pools\":{\"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3}}" + "    }" + "  }" + "}}" + "}";
+                + "    \"runtime\":{\"allocated_bytes\":10,\"resident_bytes\":20},"
+                + "    \"memory_pools\":{\"pool-a\":{\"allocated_bytes\":1,\"limit_bytes\":3,\"min_bytes\":2}}" + "  }" + "}}" + "}";
         try (final XContentParser parser = createParser(json)) {
             final NodesStatsResponse response = callFromXContent(parser);
             assertNotNull(response);
@@ -1365,7 +1350,6 @@ class HttpNodesStatsActionTest {
             assertNotNull(node.getFileCacheOnlyStats());
             assertNotNull(node.getBlockCacheOnlyStats());
             assertEquals(123456L, node.getTotalEstimatedNativeBytes());
-            assertNotNull(node.getAnalyticsBackendNativeMemoryStats());
             assertNotNull(node.getNativeAllocatorStats());
             assertNotNull(node.getJvm());
             assertNotNull(node.getTransport());
@@ -1379,16 +1363,15 @@ class HttpNodesStatsActionTest {
     void test_parseNodeStats_nativeMemory_unknownNestedObject_consumedGracefully() throws Exception {
         final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"native_memory\":{" + "  \"total_estimated_bytes\":500,"
                 + "  \"future_field\":{\"nested\":{\"deep\":true},\"count\":42},"
-                + "  \"analytics_backend\":{\"allocated_bytes\":10,\"resident_bytes\":20}," + "  \"native_allocator\":{"
-                + "    \"root\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3}," + "    \"pools\":{}" + "  }" + "}" + "}";
+                + "  \"runtime\":{\"allocated_bytes\":1,\"resident_bytes\":2}," + "  \"memory_pools\":{}" + "}" + "}";
         try (final XContentParser parser = createParser(json)) {
             parser.nextToken();
             final NodeStats nodeStats = callParseNodeStats(parser, "node1");
             assertNotNull(nodeStats);
             assertEquals(500L, nodeStats.getTotalEstimatedNativeBytes());
-            assertNotNull(nodeStats.getAnalyticsBackendNativeMemoryStats());
-            assertEquals(10L, nodeStats.getAnalyticsBackendNativeMemoryStats().getAllocatedBytes());
             assertNotNull(nodeStats.getNativeAllocatorStats());
+            assertEquals(1L, nodeStats.getNativeAllocatorStats().getNativeAllocatedBytes());
+            assertEquals(0, nodeStats.getNativeAllocatorStats().getPools().size());
         }
     }
 
@@ -1401,6 +1384,344 @@ class HttpNodesStatsActionTest {
             final NodeStats nodeStats = callParseNodeStats(parser, "node1");
             assertNotNull(nodeStats);
             assertEquals(-1L, nodeStats.getTotalEstimatedNativeBytes());
+        }
+    }
+
+    /** Renders a stats fragment to JSON so values without public getters can still be asserted. */
+    private String render(final ToXContentFragment fragment) throws IOException {
+        final XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        fragment.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        builder.flush();
+        return ((java.io.ByteArrayOutputStream) builder.getOutputStream()).toString("UTF-8");
+    }
+
+    // ==================== Sections that used to be discarded ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_indexingPressure() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"indexing_pressure\":{\"memory\":{"
+                + "  \"current\":{\"combined_coordinating_and_primary_in_bytes\":11,\"coordinating_in_bytes\":12,"
+                + "    \"primary_in_bytes\":13,\"replica_in_bytes\":14,\"all_in_bytes\":25},"
+                + "  \"total\":{\"combined_coordinating_and_primary_in_bytes\":21,\"coordinating_in_bytes\":22,"
+                + "    \"primary_in_bytes\":23,\"replica_in_bytes\":24,\"all_in_bytes\":45,"
+                + "    \"coordinating_rejections\":31,\"primary_rejections\":32,\"replica_rejections\":33}," + "  \"limit_in_bytes\":99}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final IndexingPressureStats stats = callParseNodeStats(parser, "n1").getIndexingPressureStats();
+            assertNotNull(stats);
+            assertEquals(11L, stats.getCurrentCombinedCoordinatingAndPrimaryBytes());
+            assertEquals(12L, stats.getCurrentCoordinatingBytes());
+            assertEquals(13L, stats.getCurrentPrimaryBytes());
+            assertEquals(14L, stats.getCurrentReplicaBytes());
+            assertEquals(21L, stats.getTotalCombinedCoordinatingAndPrimaryBytes());
+            assertEquals(22L, stats.getTotalCoordinatingBytes());
+            assertEquals(23L, stats.getTotalPrimaryBytes());
+            assertEquals(24L, stats.getTotalReplicaBytes());
+            assertEquals(31L, stats.getCoordinatingRejections());
+            assertEquals(32L, stats.getPrimaryRejections());
+            assertEquals(33L, stats.getReplicaRejections());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_shardIndexingPressure_shadowModeAndEnforced() throws Exception {
+        final String shadow = "{\"name\":\"n\",\"timestamp\":1,\"shard_indexing_pressure\":{\"stats\":{},"
+                + "\"total_rejections_breakup_shadow_mode\":{\"node_limits\":1,\"no_successful_request_limits\":2,"
+                + "\"throughput_degradation_limits\":3},\"enabled\":true,\"enforced\":false}}";
+        try (final XContentParser parser = createParser(shadow)) {
+            parser.nextToken();
+            final ShardIndexingPressureStats stats = callParseNodeStats(parser, "n1").getShardIndexingPressureStats();
+            assertNotNull(stats);
+            final String rendered = render(stats);
+            assertTrue(rendered.contains("\"node_limits\":1"), rendered);
+            assertTrue(rendered.contains("\"no_successful_request_limits\":2"), rendered);
+            assertTrue(rendered.contains("\"throughput_degradation_limits\":3"), rendered);
+            assertTrue(rendered.contains("\"enabled\":true"), rendered);
+            assertTrue(rendered.contains("\"enforced\":false"), rendered);
+            assertTrue(rendered.contains("total_rejections_breakup_shadow_mode"), rendered);
+        }
+        // The object is renamed once enforcement is on, so the other name must work too.
+        final String enforced = "{\"name\":\"n\",\"timestamp\":1,\"shard_indexing_pressure\":{\"stats\":{},"
+                + "\"total_rejections_breakup\":{\"node_limits\":7,\"no_successful_request_limits\":8,"
+                + "\"throughput_degradation_limits\":9},\"enabled\":true,\"enforced\":true}}";
+        try (final XContentParser parser = createParser(enforced)) {
+            parser.nextToken();
+            final ShardIndexingPressureStats stats = callParseNodeStats(parser, "n1").getShardIndexingPressureStats();
+            final String rendered = render(stats);
+            assertTrue(rendered.contains("\"node_limits\":7"), rendered);
+            assertTrue(rendered.contains("\"throughput_degradation_limits\":9"), rendered);
+            assertTrue(rendered.contains("\"enforced\":true"), rendered);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_scriptCache_contexts() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"script_cache\":{"
+                + "\"sum\":{\"compilations\":5,\"cache_evictions\":6,\"compilation_limit_triggered\":7},"
+                + "\"contexts\":[{\"context\":\"aggs\",\"compilations\":1,\"cache_evictions\":2,\"compilation_limit_triggered\":3},"
+                + "{\"context\":\"update\",\"compilations\":4,\"cache_evictions\":5,\"compilation_limit_triggered\":6}]}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final ScriptCacheStats stats = callParseNodeStats(parser, "n1").getScriptCacheStats();
+            assertNotNull(stats);
+            assertEquals(2, stats.getContextStats().size());
+            assertEquals(1L, stats.getContextStats().get("aggs").getCompilations());
+            assertEquals(2L, stats.getContextStats().get("aggs").getCacheEvictions());
+            assertEquals(3L, stats.getContextStats().get("aggs").getCompilationLimitTriggered());
+            assertEquals(4L, stats.getContextStats().get("update").getCompilations());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_clusterManagerThrottling() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"cluster_manager_throttling\":{\"stats\":{"
+                + "\"total_throttled_tasks\":5,\"throttled_tasks_per_task_type\":{\"put-mapping\":2,\"create-index\":3}}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final ClusterManagerThrottlingStats stats = callParseNodeStats(parser, "n1").getClusterManagerThrottlingStats();
+            assertNotNull(stats);
+            assertEquals(5L, stats.getTotalThrottledTaskCount());
+            assertEquals(2L, stats.getThrottlingCount("put-mapping"));
+            assertEquals(3L, stats.getThrottlingCount("create-index"));
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_adaptiveSelection() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"adaptive_selection\":{\"node-a\":{"
+                + "\"outgoing_searches\":2,\"avg_queue_size\":3,\"avg_service_time_ns\":6386680,"
+                + "\"avg_response_time_ns\":24100443,\"rank\":\"24.1\"}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final AdaptiveSelectionStats stats = callParseNodeStats(parser, "n1").getAdaptiveSelectionStats();
+            assertNotNull(stats);
+            assertEquals(2L, stats.getOutgoingConnections().get("node-a").longValue());
+            final ComputedNodeStats computed = stats.getComputedStats().get("node-a");
+            assertNotNull(computed);
+            assertEquals(3, computed.queueSize);
+            assertEquals(6386680.0, computed.serviceTime, 0.0001);
+            assertEquals(24100443.0, computed.responseTime, 0.0001);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_remoteStore_usesResponseValue() throws Exception {
+        final String json =
+                "{\"name\":\"n\",\"timestamp\":1," + "\"remote_store\":{\"last_successful_fetch_of_pinned_timestamps\":1234567890}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final RemoteStoreNodeStats stats = callParseNodeStats(parser, "n1").getRemoteStoreNodeStats();
+            assertNotNull(stats);
+            assertEquals(1234567890L, stats.getLastSuccessfulFetchOfPinnedTimestamps());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_admissionControl() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"admission_control\":{"
+                + "\"global_cpu_usage\":{\"transport\":{\"rejection_count\":{\"indexing\":4,\"search\":5}}},"
+                + "\"global_io_usage\":{\"transport\":{\"rejection_count\":{}}}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final AdmissionControlStats stats = callParseNodeStats(parser, "n1").getAdmissionControlStats();
+            assertNotNull(stats);
+            assertEquals(2, stats.getAdmissionControllerStatsList().size());
+            final Map<String, Long> byName = new HashMap<>();
+            stats.getAdmissionControllerStatsList()
+                    .forEach(c -> c.getRejectionCount().forEach((k, v) -> byName.put(c.getAdmissionControllerName() + "." + k, v)));
+            assertEquals(4L, byName.get("global_cpu_usage.indexing").longValue());
+            assertEquals(5L, byName.get("global_cpu_usage.search").longValue());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_weightedRouting_failOpenCount() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"weighted_routing\":{\"stats\":{\"fail_open_count\":3}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            assertEquals(3L, callParseNodeStats(parser, "n1").getWeightedRoutingStats().getFailOpenCount());
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_searchBackpressure_taskCounters() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"search_backpressure\":{"
+                + "\"search_task\":{\"resource_tracker_stats\":{\"cpu_usage_tracker\":{\"cancellation_count\":9}},"
+                + "  \"completion_count\":11,\"cancellation_stats\":{\"cancellation_count\":1,\"cancellation_limit_reached_count\":2}},"
+                + "\"search_shard_task\":{\"resource_tracker_stats\":{},"
+                + "  \"completion_count\":22,\"cancellation_stats\":{\"cancellation_count\":3,\"cancellation_limit_reached_count\":4}},"
+                + "\"mode\":\"monitor_only\"}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final SearchBackpressureStats stats = callParseNodeStats(parser, "n1").getSearchBackpressureStats();
+            assertNotNull(stats);
+            // SearchBackpressureStats exposes no getters, so the counters are checked as rendered.
+            final String rendered = render(stats);
+            assertTrue(rendered.contains("\"completion_count\":11"), rendered);
+            assertTrue(rendered.contains("\"cancellation_count\":1,\"cancellation_limit_reached_count\":2"), rendered);
+            assertTrue(rendered.contains("\"completion_count\":22"), rendered);
+            assertTrue(rendered.contains("\"cancellation_count\":3,\"cancellation_limit_reached_count\":4"), rendered);
+            assertTrue(rendered.contains("monitor_only"), rendered);
+        }
+    }
+
+    /**
+     * The segment statistics used to be rebuilt with the pre-2.0 wire layout while being read back at
+     * the current version, so the values landed in the wrong fields and the nested stats stayed null.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_segments_valuesAndNestedStats() throws Exception {
+        final String json = "{\"name\":\"n\",\"timestamp\":1,\"indices\":{\"segments\":{"
+                + "\"count\":5,\"memory_in_bytes\":0,\"index_writer_memory_in_bytes\":116004,"
+                + "\"version_map_memory_in_bytes\":117,\"fixed_bit_set_memory_in_bytes\":42," + "\"max_unsafe_auto_id_timestamp\":-1,"
+                + "\"remote_store\":{\"upload\":{\"total_upload_size\":{\"started_bytes\":10,\"succeeded_bytes\":11,\"failed_bytes\":12},"
+                + "  \"refresh_size_lag\":{\"total_bytes\":13,\"max_bytes\":14},\"max_refresh_time_lag_in_millis\":15,"
+                + "  \"total_time_spent_in_millis\":16,\"pressure\":{\"total_rejections\":17}},"
+                + "  \"download\":{\"total_download_size\":{\"started_bytes\":20,\"succeeded_bytes\":21,\"failed_bytes\":22},"
+                + "  \"total_time_spent_in_millis\":23}},"
+                + "\"segment_replication\":{\"max_bytes_behind\":30,\"total_bytes_behind\":31,\"max_replication_lag\":32},"
+                + "\"file_sizes\":{\"seg1\":99}}}}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final SegmentsStats stats = callParseNodeStats(parser, "n1").getIndices().getSegments();
+            assertNotNull(stats);
+            assertEquals(5L, stats.getCount());
+            assertEquals(116004L, stats.getIndexWriterMemoryInBytes());
+            assertEquals(117L, stats.getVersionMapMemoryInBytes());
+            assertEquals(42L, stats.getBitsetMemoryInBytes());
+            assertEquals(-1L, stats.getMaxUnsafeAutoIdTimestamp());
+            assertEquals(99L, stats.getFileSizes().get("seg1").longValue());
+            final RemoteSegmentStats remote = stats.getRemoteSegmentStats();
+            assertNotNull(remote);
+            assertEquals(10L, remote.getUploadBytesStarted());
+            assertEquals(11L, remote.getUploadBytesSucceeded());
+            assertEquals(12L, remote.getUploadBytesFailed());
+            assertEquals(20L, remote.getDownloadBytesStarted());
+            assertEquals(21L, remote.getDownloadBytesSucceeded());
+            assertEquals(15L, remote.getMaxRefreshTimeLag());
+            assertEquals(14L, remote.getMaxRefreshBytesLag());
+            assertEquals(13L, remote.getTotalRefreshBytesLag());
+            assertEquals(16L, remote.getTotalUploadTime());
+            assertEquals(23L, remote.getTotalDownloadTime());
+            assertEquals(17L, remote.getTotalRejections());
+        }
+    }
+
+    // ==================== Regression: nested objects must not desynchronise the parse ====================
+
+    /**
+     * A real {@code indices.search} carries a nested {@code request} object. A parse loop that only
+     * handles field names and scalars descends into it and exits early, which used to spill the
+     * remaining {@code indices} keys out as sibling nodes and drop every later section.
+     */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_indicesSearchWithNestedRequest_doesNotDesync() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"indices\":{" + "  \"docs\":{\"count\":5,\"deleted\":0},"
+                + "  \"search\":{\"open_contexts\":0,\"query_total\":6,"
+                + "    \"request\":{\"took\":{\"time_in_millis\":157,\"current\":0,\"total\":6},"
+                + "      \"query\":{\"time_in_millis\":142,\"current\":0,\"total\":6}}}," + "  \"merges\":{\"current\":0,\"total\":0},"
+                + "  \"segments\":{\"count\":3}" + "}," + "\"jvm\":{\"timestamp\":222,"
+                + "  \"mem\":{\"heap_used_in_bytes\":1000,\"heap_used_percent\":10,\"heap_committed_in_bytes\":2000,"
+                + "    \"heap_max_in_bytes\":2000,\"non_heap_used_in_bytes\":300,\"non_heap_committed_in_bytes\":400}},"
+                + "\"native_memory\":{" + "  \"total_estimated_bytes\":253865984" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertNotNull(nodeStats.getIndices());
+            // Everything after the nested object must still be reached.
+            assertNotNull(nodeStats.getJvm());
+            assertEquals(253865984L, nodeStats.getTotalEstimatedNativeBytes());
+        }
+    }
+
+    /** The same shape through fromXContent: the leftover indices keys must not become extra nodes. */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_fromXContent_indicesSearchWithNestedRequest_yieldsExactlyOneNode() throws Exception {
+        final String json = "{" + "\"_nodes\":{\"total\":1,\"successful\":1,\"failed\":0}," + "\"cluster_name\":\"test-cluster\","
+                + "\"nodes\":{\"node1\":{" + "  \"name\":\"test-node\",\"timestamp\":111," + "  \"indices\":{"
+                + "    \"search\":{\"query_total\":6,\"request\":{\"took\":{\"time_in_millis\":1,\"current\":0,\"total\":1}}},"
+                + "    \"merges\":{\"current\":0}," + "    \"refresh\":{\"total\":1}," + "    \"flush\":{\"total\":1}" + "  },"
+                + "  \"native_memory\":{\"total_estimated_bytes\":42}" + "}}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            final NodesStatsResponse response = callFromXContent(parser);
+            assertNotNull(response);
+            assertEquals(1, response.getNodes().size());
+            assertEquals("test-node", response.getNodes().get(0).getNode().getName());
+            assertEquals(42L, response.getNodes().get(0).getTotalEstimatedNativeBytes());
+        }
+    }
+
+    // ==================== Backwards compatibility: OpenSearch 3.7 native_memory shape ====================
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemory_legacy37Shape() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"native_memory\":{"
+                + "  \"total_estimated_bytes\":242368512," + "  \"analytics_backend\":{\"allocated_bytes\":1111,\"resident_bytes\":2222},"
+                + "  \"native_allocator\":{" + "    \"root\":{\"allocated_bytes\":10,\"peak_bytes\":20,\"limit_bytes\":30},"
+                + "    \"pools\":{\"pool-a\":{\"allocated_bytes\":1,\"peak_bytes\":2,\"limit_bytes\":3}}" + "  }" + "}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertNotNull(nodeStats);
+            assertEquals(242368512L, nodeStats.getTotalEstimatedNativeBytes());
+            final NativeAllocatorPoolStats stats = nodeStats.getNativeAllocatorStats();
+            assertNotNull(stats);
+            // root.allocated_bytes/peak_bytes map onto the 3.8 allocated/resident pair.
+            assertEquals(10L, stats.getNativeAllocatedBytes());
+            assertEquals(20L, stats.getNativeResidentBytes());
+            assertEquals(1, stats.getPools().size());
+            final NativeAllocatorPoolStats.PoolStats pool = stats.getPools().get(0);
+            assertEquals("pool-a", pool.getName());
+            assertEquals(1L, pool.getAllocatedBytes());
+            assertEquals(2L, pool.getPeakBytes());
+            assertEquals(3L, pool.getLimitBytes());
+        }
+    }
+
+    /** A 3.7 server that reports only totals still yields stats rather than null. */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemory_legacy37_rootOnly() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"native_memory\":{\"total_estimated_bytes\":7,"
+                + "  \"native_allocator\":{\"root\":{\"allocated_bytes\":100,\"peak_bytes\":200,\"limit_bytes\":300}}}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            final NativeAllocatorPoolStats stats = nodeStats.getNativeAllocatorStats();
+            assertNotNull(stats);
+            assertEquals(100L, stats.getNativeAllocatedBytes());
+            assertEquals(200L, stats.getNativeResidentBytes());
+            assertEquals(0, stats.getPools().size());
+        }
+    }
+
+    /** The 3.7 analytics_backend object alone has no 3.8 counterpart and must not fabricate stats. */
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void test_parseNodeStats_nativeMemory_legacy37_analyticsBackendOnly() throws Exception {
+        final String json = "{" + "\"name\":\"test-node\",\"timestamp\":111," + "\"native_memory\":{\"total_estimated_bytes\":9,"
+                + "  \"analytics_backend\":{\"allocated_bytes\":1,\"resident_bytes\":2}}" + "}";
+        try (final XContentParser parser = createParser(json)) {
+            parser.nextToken();
+            final NodeStats nodeStats = callParseNodeStats(parser, "node1");
+            assertEquals(9L, nodeStats.getTotalEstimatedNativeBytes());
+            assertNull(nodeStats.getNativeAllocatorStats());
         }
     }
 


### PR DESCRIPTION
## Summary

Bumps the OpenSearch dependency to **3.8.0** (released 2026-08-05) and the project version to `3.8.0-SNAPSHOT`, following the existing convention that the artifact version tracks the OpenSearch minor it targets.

`log4j.version` is already at `2.25.4`, which matches what OpenSearch 3.8.0 declares, so no change was needed there.

While verifying 3.x compatibility this also fixes a **pre-existing** node stats parser defect that predates the bump.

## 1. API changes required by 3.8.0

OpenSearch 3.8.0 reshapes the node stats native memory API, which breaks compilation of `HttpNodesStatsAction`:

- **`NodeStats`** no longer accepts an `AnalyticsBackendNativeMemoryStats` constructor argument. That type is now kept only for wire-level backwards compatibility, so the field, its parser and its import are removed.
- **`NativeAllocatorPoolStats`** changed from `(rootAllocatedBytes, rootPeakBytes, rootLimitBytes, pools)` to `(nativeAllocatedBytes, nativeResidentBytes, pools)`.
- **`AnalyticsBackendNativeMemoryStats`** gained a third `purgeCount` argument (no longer constructed here).

The rendered JSON under `native_memory` changed accordingly:

| | 3.7.0 | 3.8.0 |
|---|---|---|
| runtime totals | `analytics_backend` + `native_allocator.root` | `runtime` |
| per-pool | `native_allocator.pools` | `memory_pools` |
| pool fields | `allocated_bytes`, `peak_bytes`, `limit_bytes` | `allocated_bytes`, `limit_bytes`, `min_bytes`, optional `group` |

## 2. OpenSearch 3.x compatibility

`native_memory` was introduced in **3.7.0** — 3.0.0 through 3.6.0 never render it, so the reshape is a no-op for those servers.

For 3.7.0 servers, `parseLegacyNativeAllocatorStats` reads the old `native_allocator` shape into the new type, so a 3.8-built client still reports native allocator stats. The totals are mapped the way OpenSearch itself bridges the two formats (`NativeAllocatorPoolStats.writeV3_7`): allocated bytes carry over and the old peak becomes the resident value. `root.limit_bytes` has no counterpart and is dropped, as is `analytics_backend`, which 3.8 removed from `NodeStats` entirely. `parseNativeMemoryPools` also reads `peak_bytes` so legacy pools keep their peak.

## 3. Pre-existing desync fix

`parseSearchStats` and 34 sibling parse loops handled only field names and scalars. A real `indices.search` carries a nested `request` object, so the loop descended into it and exited at that object's closing token, leaving the parser out of sync.

The visible effect on a stock single-node server: a default `prepareNodesStats()` returned **13 `NodeStats` instead of 1**. The 12 extras took their node "ids" from the leftover `indices` keys (`merges`, `refresh`, `flush`, `warmer`, `query_cache`, `fielddata`, `completion`, `segments`, `translog`, `request_cache`, `recovery`, `status_counter`), and `os`, `process`, `jvm`, `thread_pool`, `fs`, `transport`, `http`, `breakers` and `native_memory` were all null.

This reproduces identically on `main` before the bump, so it is not a regression from the version change.

- Added `skipNestedValue`, applied at the end of each affected loop. It reads the parser's **current position** rather than the token the iteration started on, so it is a no-op when the loop body already consumed the value.
- Removed the `doc_status` branch in `parseIndexingStats`, which called `consumeObject` while positioned on the object's opening token and so consumed one token too many.
- Made two call sites enter the object before delegating, matching every other parse method: `_nodes` in `fromXContent`, and the file cache sections in `parseAggregateFileCacheStats`.

Why CI never caught it: `OpenSearch3ClientTest.test_stats` only asserts `!getNodes().isEmpty()`, which is true with 13 bogus nodes, and its second call passes `addMetrics(...)` that excludes `indices`. On the unit side, the test action is built with `Unsafe.allocateInstance`, so `clusterSettings` was null and any `indices` test threw a `NullPointerException` before reaching the parser. Injecting it is what makes the `indices` path testable at all.


## 4. Sections that were being discarded

Several parse methods consumed their section and returned an empty object, and two were dropped by the dispatcher, so data the response carried never reached the caller. Each is now parsed as far as the OpenSearch types allow.

| Section | Before | Now |
|---|---|---|
| `adaptive_selection` | empty maps | per-node queue size, avg service/response time |
| `script_cache` | empty map | per-context compile/eviction/limit counters |
| `indexing_pressure` | all zeros | all current/total byte counters, 3 rejection counters, limit |
| `shard_indexing_pressure` | all zeros | 3 rejection counters + `enabled` / `enforced` |
| `cluster_manager_throttling` | empty | per-task-type throttle counts |
| `remote_store` | read this node's own service | the value from the response |
| `admission_control` | **dropped** | per-controller transport rejection counts |
| `search_backpressure` task stats | discarded by an `if`/`else` running the same code | completion and cancellation counters |
| `weighted_routing.fail_open_count` | always 0 | the reported count |

`caches` is still skipped: `NodeCacheStats` needs an `ImmutableCacheStatsHolder`, whose constructor is package private and whose wire format is a recursive tree with sentinel markers.

Known limits, both because the response does not carry enough to rebuild the object: `search_backpressure` resource tracker entries (per-tracker subclasses are not identified) and `shard_indexing_pressure` per-shard entries (keyed by shard id). `adaptive_selection` recomputes `rank` rather than restoring it, since the client connection count behind it is never rendered — it still round-trips to the same value.

### `indices.segments` was returning wrong values

`parseSegmentsStats` rebuilt the object with the **pre-2.0 wire layout** while reading it back at the current version, so every field after the count landed in the wrong one, and both nested stats objects were left null.

Against a server reporting `index_writer_memory_in_bytes: 116004` and `max_unsafe_auto_id_timestamp: -1`:

| | before | after |
|---|---|---|
| `indexWriterMemoryInBytes` | `0` | `116004` |
| `maxUnsafeAutoIdTimestamp` | `0` | `-1` |
| `remoteSegmentStats` | `null` | present |

With `remoteSegmentStats` null, rendering the parsed response threw a `NullPointerException`. The layout now matches the current version, and the nested `remote_store` and `segment_replication` counters are parsed. The per-type memory fields it used to read were dropped in Lucene 9, are always rendered as zero and are not part of the wire format, so they are no longer read.

### How this was verified

Real responses from OpenSearch 3.0.0, 3.7.0 and 3.8.0 containers were parsed and rendered back through `toXContent`, then diffed against the server output. Every section above matches exactly, apart from the two unrecoverable cases noted. Unit tests cover each section with fixed JSON.

## Verification

`mvn -B package` (what CI runs) — **624 tests, 0 failures, 0 errors**, including the Testcontainers integration suites against every supported engine:

| Suite | Tests |
|---|---|
| `OpenSearch3ClientTest` (against the 3.8.0 container) | 89 |
| `OpenSearch2ClientTest` | 44 |
| `OpenSearch1ClientTest` | 41 |
| `Elasticsearch7ClientTest` | 43 |
| `Elasticsearch8ClientTest` | 43 |
| `HttpNodesStatsActionTest` | 93 |

The two desync regression tests were confirmed to fail without the guard and pass with it.

Checked against real containers — every 3.x now reports exactly one node with all sections populated:

| Server | nodes | jvm / os / fs / transport / breakers | `native_memory` |
|---|---|---|---|
| 3.8.0 | 1 (was 13) | all populated (were null) | real value (was -1) |
| 3.7.0 | 1 (was 13) | all populated (were null) | real value (was -1) |
| 3.0.0 | 1 (was 12) | all populated (were null) | -1, correct — not rendered before 3.7 |

`mvn -Prelease javadoc:jar` also runs clean, so the release path is unaffected. `mvn formatter:format && mvn license:format` were applied.

## Notes

- The install snippets in `README.md` still reference `3.7.0`, the latest version actually published to Maven Central. They are intentionally left alone so the README does not advertise an unpublished artifact; the **Supported Engines** table is updated to `3.8.0` to match the container the integration suite now runs against.
- `caches` remains the one node stats section that is still skipped, for the reason given above.
