### PR TITLE
fix(build): point the CodeLibs repository at the release path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
 		<repository>
 			<id>codelibs.org</id>
 			<name>CodeLibs Repository</name>
-			<url>https://maven.codelibs.org/</url>
+			<url>https://maven.codelibs.org/release/</url>
 		</repository>
 	</repositories>
 	<dependencies>


### PR DESCRIPTION
## Summary

The CodeLibs Maven repository now serves releases and snapshots under separate
paths. The bare host still resolves, but only as an alias for the release tree —
a snapshot path under it returns 404 — so the declaration here is legacy.

Point the `codelibs.org` repository at the explicit release path, which is what
fess-parent already declares.

## Verification

`mvn dependency:resolve` completes with no resolution errors or warnings against
the new URL.
